### PR TITLE
Fix: test warnings（[Vue warn]: Unknown custom element: <fa>）

### DIFF
--- a/test/unit/specs/pages/code-of-conduct.spec.ts
+++ b/test/unit/specs/pages/code-of-conduct.spec.ts
@@ -1,13 +1,11 @@
-import { mount, RouterLinkStub } from '@vue/test-utils'
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { shallowMount, RouterLinkStub } from '@vue/test-utils'
 import CodeOfConductPage from '~/pages/code-of-conduct.vue'
 
 describe('CodeOfConductPage', () => {
   test('レンダリングできる', () => {
-    const wrapper = mount(CodeOfConductPage, {
+    const wrapper = shallowMount(CodeOfConductPage, {
       stubs: {
-        NuxtLink: RouterLinkStub,
-        Fa: FontAwesomeIcon
+        NuxtLink: RouterLinkStub
       }
     })
     expect(wrapper.find('.code-of-conduct').isVisible()).toBeTruthy()


### PR DESCRIPTION
テスト実行時に下記 warning が出ていたので修正。

```text
console.error node_modules/vue/dist/vue.common.dev.js:630
    [Vue warn]: Unknown custom element: <fa> - did you register the component correctly? For recursive components, make sure to provide the "name" option.
```