### PR TITLE
ティザーサイトを公開する

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,9 @@
 [[redirects]]
-  from = "/*"
-  to = "/2019/:splat"
-  status = 301
-
-[[redirects]]
   from = "/2018/*"
   to = "https://vuefes-2018.netlify.com/2018/:splat"
   status = 200
+
+[[redirects]]
+  from = "/*"
+  to = "/2019/:splat"
+  status = 301


### PR DESCRIPTION
resolve: [ティザーサイト公開 · Issue #37 · kazupon/vuefes-2019](https://github.com/kazupon/vuefes-2019/issues/37)

## TODO

- [x] [ティザーサイトの最終調整（リファクタリング含む） by ryamakuchi · Pull Request #39 · kazupon/vuefes-2019](https://github.com/kazupon/vuefes-2019/pull/39) がマージされたことを確認する（必要に応じて本プルリクへ取り込む）@inouetakuya
- [x] [OGP 設定の最終調整 · Issue #40 · kazupon/vuefes-2019](https://github.com/kazupon/vuefes-2019/issues/40) が完了したことを確認する（必要に応じて本プルリクへ取り込む）@inouetakuya
- [x] `/` へのアクセスを `/2019/` へリダイレクトさせる @inouetakuya 
- [x] <https://vuefes-2018.netlify.com> で Vue Fes Japan 2018 サイトへアクセスできるよう Netlify の Site name を設定する @kazupon 
- [x] `/2018/*` へのアクセスを `https://vuefes-2018.netlify.com/2018/:splat` へ内部リダイレクトさせる @inouetakuya 
- [x] このプルリクエストをマージする @inouetakuya 
- [x] <https://vuefes-2019.netlify.com> で Vue Fes Japan 2019 サイトへアクセスできるよう Netlify を設定する（アプリケーション名、ビルドコマンドなどの設定）@kazupon
  - Site name: `vuefes-2019`
  - Base directory: (Not set)
  - Build command: `yarn generate`
  - Publish directory: `dist`
- [x] vuefes-2019 について `vuefes.jp` ドメインでアクセスできるようにする @kazupon 

## 内部リダイレクトの方法について

- [https://vuefes.jp/2018/* へのアクセスを vuefes-2018 へ転送させる方法について検討する · Issue #5 · kazupon/vuefes-2019](https://github.com/kazupon/vuefes-2019/issues/5)

## レビューポイント

- TODO に漏れがなさそうか？
  - 漏れがありそうであればコメントお願いします。レビュアーに対しては「ゼッタイにこれで漏れはない！大丈夫！」という旨を求めていません（それを求めると誰もビビってコメントできなくなるので）
