### PR TITLE
fix: ヘッド画像へ無限にリクエストが飛んでしまう

### DIFF
--- a/src/components/TheHeadSection.vue
+++ b/src/components/TheHeadSection.vue
@@ -240,7 +240,7 @@ export default class TheHeadSection extends Vue {
   ]
   patternIndex = 6
   t = 0
-  tMax = 27
+  tMax = 0
   visible = true
   windowMode: WindowMode = 'sm'
 
@@ -250,11 +250,15 @@ export default class TheHeadSection extends Vue {
     this.t = 0
 
     this.width = (grid + gap) * 5 - gap
+    this.tMax = 15
+
     if (mode === 'md') {
       this.width = (grid + gap) * 6 - gap
+      this.tMax = 18
     }
     if (mode === 'lg') {
       this.width = (grid + gap) * 9 - gap
+      this.tMax = 27
     }
   }
 


### PR DESCRIPTION
fix: [fix: ヘッド画像へ無限にリクエストが飛んでしまう · Issue #49 · kazupon/vuefes-2019](https://github.com/kazupon/vuefes-2019/issues/49)

## レビューポイント

- ひとまず現象はおさまったのですが、修正の仕方これで合っているか自信ないです
- ~~tMax って 27 で良いのだろうか？（9 x 3列 = 27 という計算をしましたが）~~
  - ウィンドウサイズによって tMax の値を変更するようにしました