### PR TITLE
お問い合わせ内容の入力可能文字数を超えた場合のエラー文言を追加し、入力可能文字数を3000に変更

### DIFF
--- a/src/components/TheContactForm.vue
+++ b/src/components/TheContactForm.vue
@@ -107,7 +107,7 @@
         <textarea
           id="message"
           v-model="formData.message"
-          v-validate="'required|max:5000'"
+          v-validate="'required|max:3000'"
           :class="{'error': errors.has('message')}"
           data-vv-validate-on="blur"
           name="message"

--- a/src/plugins/validateDictionary.ts
+++ b/src/plugins/validateDictionary.ts
@@ -8,7 +8,8 @@ const dictionary = {
       required: '名前を正しく入力してください'
     },
     message: {
-      required: '内容を正しく入力してください'
+      required: '内容を正しく入力してください',
+      max: '内容は 3,000 文字以内で入力してください'
     }
   }
 }

--- a/test/unit/specs/components/TheContactForm.spec.ts
+++ b/test/unit/specs/components/TheContactForm.spec.ts
@@ -104,6 +104,34 @@ describe('TheContactForm.Vue', () => {
       expect(error.text()).toBe('内容を正しく入力してください')
     })
 
+    test('内容が3,000文字の場合、エラーが表示されない', async () => {
+      const error = wrapper.find('#message-error')
+      expect(error.text()).toBe('')
+
+      const message = wrapper.find('#message')
+      const content = 'こんにちは'.repeat(600)
+      message.setValue(content)
+      message.trigger('blur')
+      await flushPromises()
+
+      expect(wrapper.vm.errors.any()).toEqual(false)
+      expect(error.text()).toBe('')
+    })
+
+    test('内容が3,001文字の場合、エラーが表示される', async () => {
+      const error = wrapper.find('#message-error')
+      expect(error.text()).toBe('')
+
+      const message = wrapper.find('#message')
+      const content = 'こんにちは'.repeat(600) + '！'
+      message.setValue(content)
+      message.trigger('blur')
+      await flushPromises()
+
+      expect(wrapper.vm.errors.any()).toEqual(true)
+      expect(error.text()).toBe('内容は 3,000 文字以内で入力してください')
+    })
+
     test('内容が入力されている場合、エラーが表示されない', async () => {
       const error = wrapper.find('#message-error')
       expect(error.text()).toBe('')


### PR DESCRIPTION
たびたびすみません。先日の対応で入力可能文字数を超えた場合のエラー文言を設定し忘れていたので追加しました。
（設定しなかった場合、`The message value is not valid.` が表示されます）
また、他サイトをみたところ 1,000～3,000 文字を上限としているサイトがほとんどだったので、5,000 → 3,000 としました。
お手すきの際にレビューよろしくお願いします。