### PR TITLE
fetch() メソッドの使い方をカイゼンする

### DIFF
--- a/src/components/TheContactForm.vue
+++ b/src/components/TheContactForm.vue
@@ -120,7 +120,7 @@
       </div>
 
       <BaseButton :class="{ 'has-sent': status.hasSent }" class="submit-button" type="submit">
-        {{ buttomValue }}
+        {{ buttonValue }}
       </BaseButton>
     </form>
   </BaseMain>
@@ -160,7 +160,7 @@ export default class TheContactForm extends Vue {
   @Inject('$validator')
   $validator: any
 
-  get buttomValue() {
+  get buttonValue() {
     const status = this.status
     if (status.hasError) {
       return Messages.Error

--- a/test/unit/specs/components/TheContactForm.spec.ts
+++ b/test/unit/specs/components/TheContactForm.spec.ts
@@ -32,7 +32,7 @@ describe('TheContactForm.Vue', () => {
     expect(wrapper.find('#organization').exists()).toBeTruthy()
     expect(wrapper.find('#message').exists()).toBeTruthy()
     expect(wrapper.find('.submit-button').exists()).toBeTruthy()
-    expect(wrapper.vm.buttomValue).toBe('送信する')
+    expect(wrapper.vm.buttonValue).toBe('送信する')
   })
 
   describe('フォーム操作', () => {
@@ -191,7 +191,7 @@ describe('TheContactForm.Vue', () => {
         await flushPromises()
 
         expect(wrapper.vm.errors.any()).toEqual(false)
-        expect(wrapper.vm.buttomValue).toBe('送信しました')
+        expect(wrapper.vm.buttonValue).toBe('送信しました')
       })
 
       test('送信に失敗した場合、エラーが表示される', async () => {
@@ -213,7 +213,7 @@ describe('TheContactForm.Vue', () => {
         await flushPromises()
 
         expect(wrapper.vm.errors.any()).toEqual(false)
-        expect(wrapper.vm.buttomValue).toBe('送信に失敗しました')
+        expect(wrapper.vm.buttonValue).toBe('送信に失敗しました')
       })
     })
   })


### PR DESCRIPTION
fetch() メソッドが成功したかどうかを明確に判定するには Response.ok プロパティを確認しないといけないため、そのように変更します。

例えば 404 が発生したときにも送信が成功したように見えてしまうのを防ぐ意図です。

（まあ今回のユースケースでは 404 は発生しないと思うのですが、他の箇所のコードを書く人が参考にしたときに誤解されることを防ぎたい意図でもあります。:smile:）

## 参考

Fetch を使う - Web API | MDN
https://developer.mozilla.org/ja/docs/Web/API/Fetch_API/Using_Fetch#Checking_that_the_fetch_was_successful

> fetch が成功したかチェックする
> 
> ネットワークエラーに遭遇すると fetch() promise は TypeError を返して reject 状態になります。サーバー側の CORS が適切に設定されていない場合も同様です(アクセス権の問題ですけどね) — 一方で例えば 404 はネットワークエラーを構成しません。fetch() が成功したかどうかの明確な判定をするには、プロミスが解決されて、Response.ok プロパティが true になっているかなどを確認します。次のようなコードになるでしょう。
