### PR TITLE
速度改善のために、WebFontを非同期で読み込む

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -67,7 +67,6 @@ const config: NuxtConfiguration = {
       }
     ],
     link: [
-      { rel: 'stylesheet', href: 'https://use.typekit.net/ecl1lua.css' },
       { rel: 'icon', type: 'image/x-icon', href: '/2019/favicon.ico' },
       {
         rel: 'apple-touch-icon',
@@ -78,7 +77,10 @@ const config: NuxtConfiguration = {
   },
   loading: { color: '#fff' },
   css: ['~/assets/stylesheets/main.scss'],
-  plugins: [{ src: '~/plugins/vee-validate' }],
+  plugins: [
+    { src: '~/plugins/vee-validate' },
+    { src: '~/plugins/typekit', ssr: false }
+  ],
   modules: [
     '@nuxtjs/dotenv',
     [

--- a/src/plugins/typekit.ts
+++ b/src/plugins/typekit.ts
@@ -1,0 +1,43 @@
+interface Window {
+  Typekit: any
+}
+
+;(function(d) {
+  const config = {
+    kitId: 'ecl1lua',
+    scriptTimeout: 3000,
+    async: true
+  }
+
+  const h: any = d.documentElement
+
+  const t = setTimeout(function() {
+    h.className = h.className.replace(/\bwf-loading\b/g, '') + ' wf-inactive'
+  }, config.scriptTimeout)
+
+  const tk: any = d.createElement('script')
+  let f = false
+  const s: any = d.getElementsByTagName('script')[0]
+  let a
+
+  h.className += ' wf-loading'
+  tk.src = 'https://use.typekit.net/' + config.kitId + '.js'
+  tk.async = true
+
+  tk.onload = tk.onreadystatechange = function() {
+    a = this.readyState
+
+    if (f || (a && a !== 'complete' && a !== 'loaded')) {
+      return
+    }
+
+    f = true
+    clearTimeout(t)
+
+    try {
+      window.Typekit.load(config)
+    } catch (e) {}
+  }
+
+  s.parentNode.insertBefore(tk, s)
+})(document)


### PR DESCRIPTION
ref: [チェックツールで速度改善のヒントを探る · Issue #56 · kazupon/vuefes-2019](https://github.com/kazupon/vuefes-2019/issues/56)

`font-display`は使えないようだったので、[昨年の対応](https://github.com/kazupon/vuefes/pull/222#discussion_r211093225)を真似してみました。
![image](https://user-images.githubusercontent.com/13295106/58378995-f1076280-7fd7-11e9-9c46-b5c86bf70a29.png)