### PR TITLE
お問い合わせフォームの多重送信を禁止する

### DIFF
--- a/src/components/TheContactForm.vue
+++ b/src/components/TheContactForm.vue
@@ -119,7 +119,7 @@
         </div>
       </div>
 
-      <BaseButton :disabled="status.hasSent||status.isProgressive" :class="{ 'has-sent': status.hasSent }" class="submit-button" type="submit">
+      <BaseButton :disabled="status.hasSent||status.inProgress" :class="{ 'has-sent': status.hasSent }" class="submit-button" type="submit">
         {{ buttonValue }}
       </BaseButton>
     </form>
@@ -154,7 +154,7 @@ export default class TheContactForm extends Vue {
     message: ''
   }
   status = {
-    isProgressive: false,
+    inProgress: false,
     hasSent: false,
     hasError: false
   }
@@ -166,7 +166,7 @@ export default class TheContactForm extends Vue {
     const status = this.status
     if (status.hasError) {
       return Messages.Error
-    } else if (status.isProgressive) {
+    } else if (status.inProgress) {
       return Messages.Progress
     } else if (status.hasSent) {
       return Messages.Success
@@ -177,7 +177,7 @@ export default class TheContactForm extends Vue {
 
   setStatusError(): void {
     this.status = {
-      isProgressive: false,
+      inProgress: false,
       hasSent: false,
       hasError: true
     }
@@ -185,7 +185,7 @@ export default class TheContactForm extends Vue {
 
   setStatusSuccess(): void {
     this.status = {
-      isProgressive: false,
+      inProgress: false,
       hasSent: true,
       hasError: false
     }
@@ -193,7 +193,7 @@ export default class TheContactForm extends Vue {
 
   setStatusInProgress(): void {
     this.status = {
-      isProgressive: true,
+      inProgress: true,
       hasSent: false,
       hasError: false
     }


### PR DESCRIPTION
cc: @kazupon @treby @lenomick
経緯：https://vuejs-jp.slack.com/archives/GGL7A2PQT/p1559177441005200

お問い合わせフォームを多重送信できないように修正しました。
また、送信ボタン押下後～完了するまでの間、ボタンのメッセージを「送信しています...」とするように修正しました。
複数送信することはないと思うので、一度送信ボタンを押下したらページをリロードするまで送信できないようにしています。（エラーが生じた場合は有効になります）

実装含め、文言に問題がないかも見ていただけると助かります:pray:

+ 送信前
<img src="https://user-images.githubusercontent.com/31028259/58638467-d9a9db80-832f-11e9-8e44-48f96931962a.png" width="400px">

+ 送信中
<img src="https://user-images.githubusercontent.com/31028259/58638466-d9a9db80-832f-11e9-8376-ee74b4ffe9ba.png" width="400px">

+ 送信完了
<img src="https://user-images.githubusercontent.com/31028259/58638465-d9114500-832f-11e9-8266-673e864b86c5.png" width="400px">