### PR TITLE
fix: ヘッド画像読込時にタイトルがガタつく

### DIFF
--- a/src/components/TheHeadSection.vue
+++ b/src/components/TheHeadSection.vue
@@ -329,7 +329,7 @@ $svg-grid: 120px;
 .main-visual-wrapper {
   text-align: center;
   margin: 1vw 0 5vw;
-  // SVG Parts の 1辺 x 3 + gap x 2
+  // grid の 1辺 x 3 + gap x 2
   height: calc(
     ((100vw - 7.8vw * 2 - #{$svg-gap} * 4) / 5) * 3 + #{$svg-gap} * 2
   );


### PR DESCRIPTION
fix: [fix: ヘッド画像読込時にタイトルがガタつく · Issue #62 · kazupon/vuefes-2019](https://github.com/kazupon/vuefes-2019/issues/62)

## Before

![vuefes-2019-head](https://user-images.githubusercontent.com/634357/58458695-cac2fd80-8164-11e9-8d90-8f646cb62abb.gif)

## After

<https://deploy-preview-69--vuefes-2019.netlify.com/2019/>

![vuefes-2019-head-after](https://user-images.githubusercontent.com/634357/58751715-37c7f180-84dd-11e9-9d05-1ff9fcf47599.gif)
