### PR TITLE
スペシャルスポンサーを表示できるようにする

### DIFF
--- a/src/components/TheSponsorListSection.vue
+++ b/src/components/TheSponsorListSection.vue
@@ -121,6 +121,7 @@ export default class TheSponsorListSection extends Vue {
     { plan: 'gold', name: 'GOLD' },
     { plan: 'silver', name: 'SILVER' },
     { plan: 'bronze', name: 'BRONZE' },
+    { plan: 'special', name: 'SPECIAL' },
     { plan: 'room', name: 'ROOM' },
     { plan: 'translation', name: '同時通訳' },
     { plan: 'commercial', name: '幕間 CM' },
@@ -257,7 +258,8 @@ ul {
   }
 }
 
-.sponsor-group.gold {
+.sponsor-group.gold,
+.sponsor-group.special {
   .sponsor {
     @media screen and (min-width: $layout-breakpoint--is-small-up) {
       width: calc((100% / 4) - 20px);


### PR DESCRIPTION
resolve: https://vuejs-jp.slack.com/archives/GENQVSDT3/p1561347075295700?thread_ts=1561346586.294400&cid=GENQVSDT3

スペシャルスポンサーを表示できるようにする。

## 仕様

- バナーサイズはゴールドと同じ
- 表示位置はブロンズと各種オプションとの間

## TODO

- [x] スペシャルスポンサーを表示できるようにする
- [x] Contentful の Sponsor.plan に `special` を追加する

## レビューポイント

- 仕様を満たしているか
