### PR TITLE
noteのリンクをアカウントからマガジンに変更

### DIFF
--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -63,7 +63,7 @@
 
           <a
             class="social-icon"
-            href="https://note.mu/vuejs_jp"
+            href="https://note.mu/vuejs_jp/m/mb35849fee631"
             target="_blank"
             rel="noopener"
           >


### PR DESCRIPTION
タイトルの通りです。アカウントよりもマガジンを見てもらう＆フォローしてもらう方がよいので、変更しました。

## レビューポイント
- 特になし