### PR TITLE
スポンサープランを追加する（video, media）

### DIFF
--- a/src/components/TheSponsorListSection.vue
+++ b/src/components/TheSponsorListSection.vue
@@ -140,7 +140,8 @@ export default class TheSponsorListSection extends Vue {
     { plan: 'toast', name: 'カンパイ' },
     { plan: 'lunch', name: 'LUNCH' },
     { plan: 'refreshment', name: 'REFRESHMENT' },
-    { plan: 'video', name: 'VIDEO' }
+    { plan: 'video', name: 'VIDEO' },
+    { plan: 'media', name: 'MEDIA' }
   ]
 
   @Prop()


### PR DESCRIPTION
resolve: https://vuejs-jp.slack.com/archives/GENQVSDT3/p1561940924499300?thread_ts=1561506099.357600&cid=GENQVSDT3

スポンサープランを追加する（video, media）

## 仕様

- video プランも media プランもオプションプランなので、バナーのサイズは「中」（シルバーなどと同じ）
  - ref: https://docs.google.com/presentation/d/1YSr_QVUUKZmkYMBICE3mIQl2Um9OXfeS2AKgiOHX4Ds/edit#slide=id.g55fe5830ea_0_0
- 表示位置は https://vuefes.jp/2018/ を参考にして、リフレッシュメントの次に video, media と続くようにする

## TODO

- [x] video プランのバナーを表示できるようにする
- [x] media プランのバナーを表示できるようにする
- [x] Contentful の Sponsor.plan に `video` を追加する
- [x] Contentful の Sponsor.plan に `media` を追加する

## レビューポイント

- プランの表示順とバナーの大きさが仕様と合っているか
