### PR TITLE
chore: html タグの lang 属性を ja に設定する

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -19,6 +19,9 @@ const config: NuxtConfiguration = {
   },
   hooks: hooks(this),
   head: {
+    htmlAttrs: {
+      lang: 'ja'
+    },
     title: defaultTitle,
     meta: [
       { charset: 'utf-8' },


### PR DESCRIPTION
html タグの lang 属性を設定しておらず、デフォルトの en のままだったので ja に変更する。

Twitter で指摘いただいた。

- https://vuejs-jp.slack.com/archives/GENQVSDT3/p1561985536032200
- https://twitter.com/tyankatsu5/status/1145518057877454848?s=12

## レビューポイント

- html タグの lang 属性が正しく設定されているか
