### PR TITLE
chore(test): Jest のワーカー数を2にするよう変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "stylelint": "stylelint 'src/**/*.vue' 'src/**/*.scss'",
     "stylelint:fix": "yarn stylelint --fix",
     "test": "jest --verbose",
-    "test:ci": "jest --ci --coverage --no-cache"
+    "test:ci": "jest --ci --coverage --no-cache --maxWorkers=2"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## 概要
チケットセクションのボタン有効化を対応している際に発生したのですが（[CI#378](https://circleci.com/gh/kazupon/vuefes-2019/378)）、前からちょこちょこ発生していた（[CI#370](https://circleci.com/gh/kazupon/vuefes-2019/370)、[CI#374](https://circleci.com/gh/kazupon/vuefes-2019/374)）ようなので修正PRです

## レビューポイント
- 対応が適切か
  - デフォルトだと jest はワーカー数1で動くらしいので`--maxWorkers` でワーカー数を2に設定しました。

## 備考
2~3回動かした限りでは大丈夫そう...と思っていたのですが、毎回必ず発生するわけではないので微妙ですね:bow:

ただ、テストの実行時間はかなり短縮することができました。
ワーカー数を増やす前（[CI#376](https://circleci.com/gh/kazupon/vuefes-2019/376)）：`Time:        68.69s`
ワーカー数を増やした後（[CI#384](https://circleci.com/gh/kazupon/vuefes-2019/384)）：`Time:        6.268s`

もしまた発生したら再考します。

## 参考
+ https://jestjs.io/docs/en/cli#runinband
+ https://jestjs.io/docs/en/cli#maxworkers-num-string
+ https://blog.bam.tech/developper-news/optimise-jest-in-ci-and-save-hours-a-week-literally-1
+ https://vgpena.github.io/jest-circleci/