### PR TITLE
feat: Ticket セクションのボタンを有効化する

### DIFF
--- a/src/components/TheTicketSection.vue
+++ b/src/components/TheTicketSection.vue
@@ -68,10 +68,11 @@
       ※別途クレジットカード決済手数料（0.35%）がかかります。
     </p>
 
-    <BaseButton class="ticket-button" disabled>
-      発売開始予定
-      <br class="show-on-small" />
-      7/17（水）12:00〜
+    <BaseButton
+      class="ticket-button"
+      href="https://www.universe.com/events/vue-fes-japan-2019-tickets--YG3SMV"
+    >
+      チケットを購入する
     </BaseButton>
 
     <div class="faq">

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -45,5 +45,11 @@ import TheStoreSection from '~/components/TheStoreSection.vue'
     }
   }
 })
-export default class HomePage extends Vue {}
+export default class HomePage extends Vue {
+  private head() {
+    return {
+      script: [{ src: 'https://www.universe.com/embed2.js' }]
+    }
+  }
+}
 </script>


### PR DESCRIPTION
## レビューポイント

- ボタン押下でダイアログが表出するか
  - 現在はチケット情報を公開していないので、ダイアログは表出はしますが詳細（価格等）は表示されません（詳細を表示するか #126 で議論中です）
- ボタンのテキストの文言は適切か
  - 他のボタンの文言が体言止めだったので、それに倣って`購入`にしましたが、いかがでしょうか
    https://github.com/kazupon/vuefes-2019/blob/33466f1b08645ab73a341c9830af6269aaa7f439/src/components/TheTicketSection.vue#L75

## 注意事項

販売開始が `7/17 12:00～` なのでそれまではマージしないようよろしくお願いしますmm

close #126