### PR TITLE
fix: セッション詳細ページの OGP 画像が表示されていない

### DIFF
--- a/src/pages/sessions/_speakerId.vue
+++ b/src/pages/sessions/_speakerId.vue
@@ -120,7 +120,7 @@ export default class SessionPage extends Vue {
       this.speaker.name
     } が、「${this.session.title}」を発表します。`
     const ogImageUrl = `https://vuefes.jp/2019/session-og-images/${
-      this.session.speakerId
+      this.session.ogImage
     }`
 
     return {


### PR DESCRIPTION
表題のとおりです。

- https://vuejs-jp.slack.com/archives/GENQVSDT3/p1563262907342700

## レビューポイント

- OGP 画像の URL が正しいか
