### PR TITLE
[No merge] fix(test): セッション詳細ページのテストを実行する（Another）

### DIFF
--- a/test/unit/specs/pages/sessions/_speakerId.spec.ts
+++ b/test/unit/specs/pages/sessions/_speakerId.spec.ts
@@ -20,7 +20,6 @@ describe('SessionPage', () => {
     config.rootDir = resolve(__dirname, '../../../../..')
     nuxt = new Nuxt(config)
     await new Builder(nuxt).build()
-    await nuxt.listen(4000, 'localhost')
   })
 
   afterAll(() => {


### PR DESCRIPTION
[fix(test): セッション詳細ページのテストを実行するよう修正 by aytdm · Pull Request #146 · kazupon/vuefes-2019](https://github.com/kazupon/vuefes-2019/pull/146) を見ていたら勇気が湧いてきたので別解にチャレンジしてみた。

## 解決したい問題

vue-test-utils で Page コンポーネントをマウントするときに、マウント前に asyncData が実行されないため、asyncData の実行を前提とした箇所でエラーが発生する。

## どのように解決するか

nuxt.renderRoute を実行することで asyncData が実行されるようにする。

## 参考

- [API: nuxt.renderRoute(route, context) - Nuxt.js](https://ja.nuxtjs.org/api/nuxt-render-route)
- https://github.com/nuxt/nuxt.js/tree/dev/test/unit

あたりを参考にした。

## 結論

- `TypeError: this._ssrNode is not a function` というエラーが発生するのを倒せていない
- 仮に倒せたとしても、vue-test-utils の便利メソッドを使えないやり方なので、asyncData が絡むところを全部 `nuxt.renderRoute` 使うようにするかというと、厳しいと思う

がんばってみましたという点だけ認めてください ☺️ 

@aytdm が確認してくれたらクローズします〜
