### PR TITLE
doc: チケットセクションに文言を追加

### DIFF
--- a/src/components/TheTicketSection.vue
+++ b/src/components/TheTicketSection.vue
@@ -14,6 +14,11 @@
       <p>
         購入時に届くメールに QR コードが記載されていますので、そちらをチケットとして当日ご持参ください。
       </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        チケットに関するお問い合わせは、<nuxt-link class="link" to="/contact/">お問い合わせページ</nuxt-link>からお願いします。
+      </p>
     </div>
 
     <div class="ticket-list">


### PR DESCRIPTION
Twitter からお問い合わせが来たり、問い合わせの窓口がバラバラになっているのでチケットセクションに明記するようにしました。また、Slack でやりとりのあった`チケットの種類変更については、チケット販売終了後は受け付けておりません`については、お問い合わせがあった人のみ対応したいので明記しませんでした。（した方がいいでしょうか...）

## レビューポイント
- 何か気になるところがあれば指摘をお願いします

## 参考
https://vuejs-jp.slack.com/archives/GENQVSDT3/p1566650899275400?thread_ts=1566649833.274100&cid=GENQVSDT3
