### PR TITLE
Revert "awk(nawk)で画像リサイズできるようにする"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ git commit --no-verify
 
 画像ファイルを追加または変更した場合には、コミット時に [sharp](https://github.com/lovell/sharp) により自動でリサイズされます。
 
+リサイズには、gawk を使っているためインストールが必要です。
+
+Mac で Homebrew を使っている場合は、以下のコマンドでインストールできます。
+
+```shell
+brew install gawk
+```
+
 ## Testing
 
 ```shell

--- a/bin/resize-images
+++ b/bin/resize-images
@@ -6,8 +6,9 @@ set -ue -o pipefail
 # Prevent commands misbehaving due to locale differences
 export LC_ALL=C
 
+# FIXME: \w+ の正規表現がawk(nawk)では使えないので、gawkにしている (awkにできるならawkにしたい)
 for file in `git diff --cached --name-status | \
-  awk '$1 ~ /[AM]/ && tolower($2) ~ /src\/assets\/images\/staffs\/(?!@2x\/).+\.(jpe?g|png|gif|svg)$/ {print $2}'`
+  gawk '$1 ~ /[AM]/ && tolower($2) ~ /src\/assets\/images\/staffs\/\w+\.(jpe?g|png|gif|svg)$/ {print $2}'`
 do
   echo コアスタッフの $file をリサイズします
   cat $file | ./node_modules/.bin/sharp \
@@ -16,8 +17,9 @@ do
   git add $file
 done
 
+# FIXME: \w+ の正規表現がawk(nawk)では使えないので、gawkにしている (awkにできるならawkにしたい)
 for file in `git diff --cached --name-status | \
-  awk '$1 ~ /[AM]/ && tolower($2) ~ /src\/assets\/images\/staffs\/@2x\/.+\.(jpe?g|png|gif|svg)$/ {print $2}'`
+  gawk '$1 ~ /[AM]/ && tolower($2) ~ /src\/assets\/images\/staffs\/@2x\/\w+\.(jpe?g|png|gif|svg)$/ {print $2}'`
 do
   echo コアスタッフ@2xの $file をリサイズします
   cat $file | ./node_modules/.bin/sharp \


### PR DESCRIPTION
Reverts kazupon/vuefes-2019#173

https://github.com/kazupon/vuefes-2019/pull/173#issuecomment-528823720

## エラー

pre-commit 時に

```
awk: illegal primary in regular expression
```

というエラーが発生してしまったため、泣く泣く Revert します。

一旦仕切り直しましょう〜 ☺️ 

## 詳細

```
[@GISELE.local vuefes-2019]$ git wip
husky > pre-commit (node v10.15.3)
yarn run v1.17.3
$ yarn eslint && yarn stylelint
$ eslint --ext .ts,.js,.vue --ignore-path .gitignore .
$ stylelint 'src/**/*.vue' 'src/**/*.scss'
✨  Done in 6.42s.
awk: illegal primary in regular expression src\/assets\/images\/staffs\/(?!@2x\/).+\.(jpe?g|png|gif|svg)$ at !@2x\/).+\.(jpe?g|png|gif|svg)$
 source line number 1
 context is
        $1 ~ /[AM]/ && tolower($2) ~ >>>  /src\/assets\/images\/staffs\/(?!@2x\/).+\.(jpe?g|png|gif|svg)$/ <<<
[volunteers 569ca02] wip
```
