### PR TITLE
refactor: Contentful API から取得するデータと区別するために sessions と speakers をリネーム

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,7 @@
 import NuxtConfiguration from '@nuxt/config'
 import StylelintPlugin from 'stylelint-webpack-plugin'
 import hooks from './src/hooks'
-import * as sessions from './src/store/sessions'
+import * as localSessions from './src/store/localSessions'
 
 require('dotenv').config()
 
@@ -135,7 +135,7 @@ const config: NuxtConfiguration = {
   },
   generate: {
     dir: 'dist/2019',
-    routes: sessions
+    routes: localSessions
       .state()
       .sessions.map(session => `/sessions/${session.speakerId}`)
   },

--- a/src/components/TheSpeakerListSection.vue
+++ b/src/components/TheSpeakerListSection.vue
@@ -40,7 +40,7 @@
 
 <script lang="ts">
 import { Component, Getter, Vue } from 'nuxt-property-decorator'
-import { Speaker } from '~/store/speakers'
+import { LocalSpeaker } from '~/store/localSpeakers'
 import BaseSection from '~/components/BaseSection.vue'
 
 @Component({
@@ -49,8 +49,8 @@ import BaseSection from '~/components/BaseSection.vue'
   }
 })
 export default class TheSpeakerListSection extends Vue {
-  @Getter('all', { namespace: 'speakers' })
-  speakers!: Speaker[]
+  @Getter('all', { namespace: 'localSpeakers' })
+  speakers!: LocalSpeaker[]
 }
 </script>
 

--- a/src/pages/sessions/_speakerId.vue
+++ b/src/pages/sessions/_speakerId.vue
@@ -82,8 +82,8 @@
 <script lang="ts">
 import { Component, Getter, Vue } from 'nuxt-property-decorator'
 import { Context } from '@nuxt/vue-app'
-import { Session } from '~/store/sessions'
-import { Speaker } from '~/store/speakers'
+import { LocalSession } from '~/store/localSessions'
+import { LocalSpeaker } from '~/store/localSpeakers'
 import BaseMain from '~/components/BaseMain.vue'
 import BaseButton from '~/components/BaseButton.vue'
 
@@ -109,11 +109,11 @@ export default class SessionPage extends Vue {
 
   path!: string
 
-  @Getter('sessionBySpeakerId', { namespace: 'sessions' })
-  sessionBySpeakerId!: (speakerId: string) => Session
+  @Getter('sessionBySpeakerId', { namespace: 'localSessions' })
+  sessionBySpeakerId!: (speakerId: string) => LocalSession
 
-  @Getter('speakerById', { namespace: 'speakers' })
-  speakerById!: (id: string) => Speaker
+  @Getter('speakerById', { namespace: 'localSpeakers' })
+  speakerById!: (id: string) => LocalSpeaker
 
   head() {
     const url = `https://vuefes.jp/2019${this.path}`
@@ -150,14 +150,14 @@ export default class SessionPage extends Vue {
     }
   }
 
-  get session(): Session {
+  get session(): LocalSession {
     if (process.env.NODE_ENV === 'test') {
       this.setValueIfUndefined()
     }
     return this.sessionBySpeakerId(this.speakerId)
   }
 
-  get speaker(): Speaker {
+  get speaker(): LocalSpeaker {
     if (process.env.NODE_ENV === 'test') {
       this.setValueIfUndefined()
     }
@@ -165,7 +165,7 @@ export default class SessionPage extends Vue {
   }
 
   private setValueIfUndefined(): void {
-    // テストが失敗しないようにundefinedの場合は値を設定する
+    // テストが失敗しないように undefined の場合は値を設定する
     if (this.speakerId === undefined) {
       this.speakerId = 'yyx990803'
     }

--- a/src/store/localSessions.ts
+++ b/src/store/localSessions.ts
@@ -1,6 +1,6 @@
 import { Getters } from '~/types/store'
 
-export type Session = {
+export type LocalSession = {
   speakerId: string
   title: string
   time: number
@@ -8,17 +8,17 @@ export type Session = {
   ogImage: string
 }
 
-namespace Sessions {
+namespace LocalSessions {
   export type State = {
-    sessions: Session[]
+    sessions: LocalSession[]
   }
 
   export type Getters = {
-    sessionBySpeakerId: (speakerId: string) => Session
+    sessionBySpeakerId: (speakerId: string) => LocalSession
   }
 }
 
-export const state = (): Sessions.State => ({
+export const state = (): LocalSessions.State => ({
   sessions: [
     {
       speakerId: 'yyx990803',
@@ -207,7 +207,7 @@ export const state = (): Sessions.State => ({
   ]
 })
 
-export const getters: Getters<Sessions.State, Sessions.Getters> = {
+export const getters: Getters<LocalSessions.State, LocalSessions.Getters> = {
   sessionBySpeakerId: state => speakerId => {
     const session = state.sessions.find(
       session => session.speakerId === speakerId

--- a/src/store/localSpeakers.ts
+++ b/src/store/localSpeakers.ts
@@ -1,6 +1,6 @@
 import { Getters } from '~/types/store'
 
-export type Speaker = {
+export type LocalSpeaker = {
   id: string
   avatar: string
   avatar2x: string
@@ -11,18 +11,18 @@ export type Speaker = {
   paragraphs: string[]
 }
 
-namespace Speakers {
+namespace LocalSpeakers {
   export type State = {
-    speakers: Speaker[]
+    speakers: LocalSpeaker[]
   }
 
   export type Getters = {
-    all: Speaker[]
-    speakerById: (id: string) => Speaker
+    all: LocalSpeaker[]
+    speakerById: (id: string) => LocalSpeaker
   }
 }
 
-export const state = (): Speakers.State => ({
+export const state = (): LocalSpeakers.State => ({
   speakers: [
     {
       id: 'yyx990803',
@@ -239,7 +239,7 @@ export const state = (): Speakers.State => ({
   ]
 })
 
-export const getters: Getters<Speakers.State, Speakers.Getters> = {
+export const getters: Getters<LocalSpeakers.State, LocalSpeakers.Getters> = {
   all: state => {
     return state.speakers
   },

--- a/test/unit/specs/store/localSessions.spec.ts
+++ b/test/unit/specs/store/localSessions.spec.ts
@@ -1,8 +1,8 @@
-import { state, getters } from '~/store/sessions'
+import { state, getters } from '~/store/localSessions'
 
 describe('getters', () => {
   describe('sessionBySpeakerId', () => {
-    test('Session を speakerId をもとに取得できる', () => {
+    test('LocalSession を speakerId をもとに取得できる', () => {
       const session = getters.sessionBySpeakerId(state())('yyx990803')
       expect(session.speakerId).toBe('yyx990803')
     })

--- a/test/unit/specs/store/localSpeakers.spec.ts
+++ b/test/unit/specs/store/localSpeakers.spec.ts
@@ -1,15 +1,15 @@
-import { state, getters } from '~/store/speakers'
+import { state, getters } from '~/store/localSpeakers'
 
 describe('getters', () => {
   describe('all', () => {
-    test('Speaker の配列を取得できる', () => {
+    test('LocalSpeaker の配列を取得できる', () => {
       const speakers = getters.all(state())
       expect(speakers).toEqual(state().speakers)
     })
   })
 
   describe('speakerById', () => {
-    test('Speaker を id をもとに取得できる', () => {
+    test('LocalSpeaker を id をもとに取得できる', () => {
       const speaker = getters.speakerById(state())('yyx990803')
       expect(speaker.id).toBe('yyx990803')
     })

--- a/test/unit/specs/utils/createFullStore.ts
+++ b/test/unit/specs/utils/createFullStore.ts
@@ -1,16 +1,16 @@
-import * as sessions from '~/store/sessions'
-import * as speakers from '~/store/speakers'
+import * as localSessions from '~/store/localSessions'
+import * as localSpeakers from '~/store/localSpeakers'
 
 export default Vuex => {
   return new Vuex.Store({
     modules: {
-      sessions: {
+      localSessions: {
         namespaced: true,
-        ...sessions
+        ...localSessions
       },
-      speakers: {
+      localSpeakers: {
         namespaced: true,
-        ...speakers
+        ...localSpeakers
       }
     }
   })


### PR DESCRIPTION
[feat: タイムテーブル情報を Contentful から取得＆描画するよう変更 by inouetakuya · Pull Request #177 · kazupon/vuefes-2019](https://github.com/kazupon/vuefes-2019/pull/177) を進めていますが、既存のローカルのセッション情報、スピーカー情報と、Contentful API から取得するデータとを区別する必要があります。

なお、いずれ、Contentful API から取得するデータで一元化しますが、暫定的な措置です。

#177 に含めると差分が膨れ上がるため、別プルリクエストに切り出しました。

## レビューポイント

- 正常に動作するか？
