### PR TITLE
2020のサイトを公開する

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@
   status = 200
 
 [[redirects]]
+  from = "/2020/*"
+  to = "https://vuefes-2020.netlify.app/2020/:splat"
+  status = 200
+
+[[redirects]]
   from = "/*"
-  to = "/2019/:splat"
+  to = "/2020/:splat"
   status = 301


### PR DESCRIPTION
2020の公開のため

- /2020 でhttps://vuefes-2020.netlify.app/2020/ へproxyする
- https://vuefes.jp/ を https://vuefes.jp/2020 へリダイレクト
   - 今は2019にリダイレクトされているため
