### PR TITLE
2019のリダイレクト設定を追加

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@
   status = 200
 
 [[redirects]]
+  from = "/2019/*"
+  to = "https://vuefes-2019.netlify.com/2019/:splat"
+  status = 200
+
+[[redirects]]
   from = "/2020/*"
   to = "https://vuefes-2020.netlify.app/2020/:splat"
   status = 200


### PR DESCRIPTION
2022のWEBサイトにリダイレクトされてしまい、OGP画像が表示されなかった不具合が修正される

resolve 

## TODO
- [ ] 

## レビューポイント
- 

## 参考
