### PR TITLE
feat: update netlify.toml for 2024

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,29 +1,34 @@
 [[redirects]]
-  from = "/2018/*"
-  to = "https://vuefes-2018.netlify.com/2018/:splat"
-  status = 200
+from = "/2018/*"
+to = "https://vuefes-2018.netlify.com/2018/:splat"
+status = 200
 
 [[redirects]]
-  from = "/2019/*"
-  to = "https://vuefes-2019.netlify.com/2019/:splat"
-  status = 200
+from = "/2019/*"
+to = "https://vuefes-2019.netlify.com/2019/:splat"
+status = 200
 
 [[redirects]]
-  from = "/2020/*"
-  to = "https://vuefes-2020.netlify.app/2020/:splat"
-  status = 200
+from = "/2020/*"
+to = "https://vuefes-2020.netlify.app/2020/:splat"
+status = 200
 
 [[redirects]]
-  from = "/2022/*"
-  to = "https://vuefes-2022.netlify.app/2022/:splat"
-  status = 200
+from = "/2022/*"
+to = "https://vuefes-2022.netlify.app/2022/:splat"
+status = 200
 
 [[redirects]]
-  from = "/2023/*"
-  to = "https://vuefes-2023.netlify.app/2023/:splat"
-  status = 200
+from = "/2023/*"
+to = "https://vuefes-2023.netlify.app/2023/:splat"
+status = 200
 
 [[redirects]]
-  from = "/*"
-  to = "/2023/:splat"
-  status = 301
+from = "/2024/*"
+to = "https://vuefes-2024.netlify.app/2024/:splat"
+status = 200
+
+[[redirects]]
+from = "/*"
+to = "/2024/:splat"
+status = 301


### PR DESCRIPTION
resolve 
https://github.com/vuejs-jp/vuefes-2024-backside/issues/73

update netlify.toml for 2024

### Now
https://vuefes.jp/ で公開中
https://vuefes.jp/2023/ にリダイレクト

## After
- https://vuefes.jp/ で公開中
  - https://vuefes.jp/2024/ にリダイレクト
- https://vuefes.jp/2024/ は
  - https://vuefes-2024.netlify.app/2024/ にリダイレクト

## レビューポイント
- インデントが消えたのはフォーマッタのせいです

## 参考
