### PR TITLE
feat: add redirect for 2025 for test

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,6 +29,11 @@ to = "https://vuefes-2024.netlify.app/2024/:splat"
 status = 200
 
 [[redirects]]
+from = "/2025/*"
+to = "https://vuefes-2025.netlify.app/2025/:splat"
+status = 200
+
+[[redirects]]
 from = "/*"
 to = "/2024/:splat"
 status = 301


### PR DESCRIPTION
resolve 

## TODO
- [ ] 

## レビューポイント
- テスト用 2025 リダイレクト
    - `https://vuefes.jp/*` のリダイレクトは設定していないので `https://vuefes.jp/2025/` 配下へアクセスした際のみ、 `https://vuefes-2025.netlify.app/2025/` のプロジェクトが表示されるはず

## 参考
