### PR TITLE
feat: update redirect from 2024 to 2025 in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,5 +35,5 @@ status = 200
 
 [[redirects]]
 from = "/*"
-to = "/2024/:splat"
+to = "/2025/:splat"
 status = 301


### PR DESCRIPTION
# 2025/4/1 11:50 にマージして公開予定です

## TODO
- [ ] 

## レビューポイント
- 2025 へのリダイレクトを追加

## 補足
- `https://vuefes.jp/2025/` へのアクセスの設定に関しては下記で取り込み済みかつ、現在は 2024 のものに戻してある状態です。
https://github.com/vuejs-jp/vuefes-2019/pull/224
- 今回のPRマージすることで `https://vuefes.jp/2025/` へのアクセスでの表示も含まれた状態となります。