### PR TITLE
modernize continued

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "npm run generate"
+command = "corepack enable && corepack pnpm run generate"
 publish = ".output/public"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "corepack enable && corepack pnpm install --frozen-lockfile && corepack pnpm run generate"
+command = "corepack enable && rm -rf node_modules && corepack pnpm install --frozen-lockfile && corepack pnpm run generate"
 publish = ".output/public"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "corepack pnpm run generate"
+command = "corepack enable && rm -rf node_modules && corepack pnpm install --frozen-lockfile && corepack pnpm run generate"
 publish = "dist/2019"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "corepack enable && corepack pnpm run generate"
+command = "corepack enable && corepack pnpm install --frozen-lockfile && corepack pnpm run generate"
 publish = ".output/public"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
+[build]
+command = "npm run generate"
+publish = ".output/public"
+
 [build.environment]
 NODE_VERSION = "24"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,3 @@
-# https://github.com/vuejs-jp/vuefes-2019/issues/235
 [build]
 command = "corepack pnpm run generate"
 publish = "dist/2019"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 command = "corepack enable && rm -rf node_modules && corepack pnpm install --frozen-lockfile && corepack pnpm run generate"
-publish = ".output/public"
+publish = "dist/2019"
 
 [build.environment]
 NODE_VERSION = "24"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
+# https://github.com/vuejs-jp/vuefes-2019/issues/235
 [build]
 command = "corepack pnpm run generate"
 publish = "dist/2019"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "corepack enable && rm -rf node_modules && corepack pnpm install --frozen-lockfile && corepack pnpm run generate"
+command = "corepack pnpm run generate"
 publish = "dist/2019"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
     "nuxt": "^4.4.2"
   },
   "devDependencies": {
-    "@nuxt/test-utils": "^3.20.0",
+    "@nuxt/test-utils": "^4.0.0",
     "@vue/language-core": "^3.2.6",
     "@vue/test-utils": "^2.4.6",
-    "happy-dom": "^18.0.1",
+    "happy-dom": "^20.8.9",
     "sass-embedded": "^1.89.0",
     "typescript": "^5.8.3",
     "vite-plus": "^0.1.14",
-    "vitest": "^3.2.4",
+    "vitest": "^4.1.2",
     "vue-tsc": "^3.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typescript": "^5.8.3",
     "vite-plus": "^0.1.14",
     "vitest": "^4.1.2",
+    "vue": "3.6.0-beta.9",
     "vue-tsc": "^3.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^5.8.3",
     "vite-plus": "^0.1.14",
     "vitest": "^4.1.2",
-    "vue": "3.6.0-beta.1",
+    "vue": "3.5.30",
     "vue-router": "5.0.4",
     "vue-tsc": "^3.2.6"
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^5.8.3",
     "vite-plus": "^0.1.14",
     "vitest": "^4.1.2",
-    "vue": "3.6.0-beta.9",
+    "vue": "3.6.0-beta.1",
     "vue-router": "5.0.4",
     "vue-tsc": "^3.2.6"
   }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "vite-plus": "^0.1.14",
     "vitest": "^4.1.2",
     "vue": "3.6.0-beta.9",
+    "vue-router": "5.0.4",
     "vue-tsc": "^3.2.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       vue:
         specifier: 3.6.0-beta.9
         version: 3.6.0-beta.9(typescript@5.9.3)
+      vue-router:
+        specifier: 5.0.4
+        version: 5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.6.0-beta.9(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -6068,6 +6071,16 @@ snapshots:
     optionalDependencies:
       vue: 3.5.30(typescript@5.9.3)
 
+  '@vue-macros/common@3.1.2(vue@3.6.0-beta.9(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-sfc': 3.5.30
+      ast-kit: 2.2.0
+      local-pkg: 1.1.2
+      magic-string-ast: 1.0.3
+      unplugin-utils: 0.3.1
+    optionalDependencies:
+      vue: 3.6.0-beta.9(typescript@5.9.3)
+
   '@vue/babel-helper-vue-transform-on@2.0.1': {}
 
   '@vue/babel-plugin-jsx@2.0.1(@babel/core@7.29.0)':
@@ -8921,6 +8934,29 @@ snapshots:
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
       vue: 3.5.30(typescript@5.9.3)
+      yaml: 2.8.3
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.30
+
+  vue-router@5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.6.0-beta.9(typescript@5.9.3)):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@vue-macros/common': 3.1.2(vue@3.6.0-beta.9(typescript@5.9.3))
+      '@vue/devtools-api': 8.1.1
+      ast-walker-scope: 0.8.3
+      chokidar: 5.0.0
+      json5: 2.2.3
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      muggle-string: 0.4.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      scule: 1.3.0
+      tinyglobby: 0.2.15
+      unplugin: 3.0.0
+      unplugin-utils: 0.3.1
+      vue: 3.6.0-beta.9(typescript@5.9.3)
       yaml: 2.8.3
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.30

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 6.7.2
       '@fortawesome/vue-fontawesome':
         specifier: ^3.0.8
-        version: 3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.5.30(typescript@5.9.3))
+        version: 3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.6.0-beta.9(typescript@5.9.3))
       contentful:
         specifier: ^11.5.20
         version: 11.12.0
@@ -60,6 +60,9 @@ importers:
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+      vue:
+        specifier: 3.6.0-beta.9
+        version: 3.6.0-beta.9(typescript@5.9.3)
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -1837,14 +1840,29 @@ packages:
   '@vue/compiler-core@3.5.30':
     resolution: {integrity: sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==}
 
+  '@vue/compiler-core@3.6.0-beta.9':
+    resolution: {integrity: sha512-/qlfk4cbU//tgdwWeAbl4kBvH5ZocjJ6CMGigzRKk1So/0jl6kRpFxVbc6oNsYYH6Xj28ByA+msAes1FjExejg==}
+
   '@vue/compiler-dom@3.5.30':
     resolution: {integrity: sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==}
+
+  '@vue/compiler-dom@3.6.0-beta.9':
+    resolution: {integrity: sha512-Bh2h+Co2Vl85jhNjR+yBU1oIujqQ3XIhF7FzODBStvp8yn2WvsXmm5QlvnE7q+smJkfglTbfFcaou8fjR0Y4ag==}
 
   '@vue/compiler-sfc@3.5.30':
     resolution: {integrity: sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==}
 
+  '@vue/compiler-sfc@3.6.0-beta.9':
+    resolution: {integrity: sha512-13MwFqrIN+AFxR5uT88WYaMTxXycpNNI75sIllz5blXbFaBsDfiegQZj10Pj5G3cgH7WFy2Trs1rTlXrmSgG/w==}
+
   '@vue/compiler-ssr@3.5.30':
     resolution: {integrity: sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==}
+
+  '@vue/compiler-ssr@3.6.0-beta.9':
+    resolution: {integrity: sha512-ufzHVMJoMz7QzMFop03a8KpWAWUh4hiof/tJXvxiDClIFUY7P5OrKk644fV9qlWgTP7V+eQvA7kVSEVRUgYjvA==}
+
+  '@vue/compiler-vapor@3.6.0-beta.9':
+    resolution: {integrity: sha512-1WWCcRjkH/scYJ8dsjNp8+NDf4f9SwQgOcd4Hbl5p0srNPflqrQYvAaJh4N2Szxj5FdkXw2t5uiK35TpFM5uKA==}
 
   '@vue/devtools-api@8.1.1':
     resolution: {integrity: sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==}
@@ -1866,19 +1884,41 @@ packages:
   '@vue/reactivity@3.5.30':
     resolution: {integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==}
 
+  '@vue/reactivity@3.6.0-beta.9':
+    resolution: {integrity: sha512-Mo0GjZB/q7LUJplPjBdKqAAk4mawkzvnk2nNf9CEetp4RQJP5/e/DdmgjYBsr/+UVX5ShasCalwdyknuuIepdw==}
+
   '@vue/runtime-core@3.5.30':
     resolution: {integrity: sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==}
 
+  '@vue/runtime-core@3.6.0-beta.9':
+    resolution: {integrity: sha512-IPbO/cmw0BSHec17fSE8Mbtv0UFBiiiGhvlUGiJWTa/eOlbiO+mZ9/PRRUQ+v/tkKuwFSzKye7KOKj5aFO1dgQ==}
+
   '@vue/runtime-dom@3.5.30':
     resolution: {integrity: sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==}
+
+  '@vue/runtime-dom@3.6.0-beta.9':
+    resolution: {integrity: sha512-+WV0V1s/uf9iFwZt41lOtJHbIqKyYdEO+nmW0UOnQLjG9ELz6rKuZ92fEim6NPcKCsucv2BoB1mK9T82khYqgg==}
+
+  '@vue/runtime-vapor@3.6.0-beta.9':
+    resolution: {integrity: sha512-UlAziGF77byUa84RgkIdCT4bleZbB4UvQvmxdGHFfscGylSABBZHAMR8WJIwBsy1MsZnlpRSSeDAYB20RicrhQ==}
+    peerDependencies:
+      '@vue/runtime-dom': 3.6.0-beta.9
 
   '@vue/server-renderer@3.5.30':
     resolution: {integrity: sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==}
     peerDependencies:
       vue: 3.5.30
 
+  '@vue/server-renderer@3.6.0-beta.9':
+    resolution: {integrity: sha512-qyz37g6pmwHvtXbe7CWKm5+VTmCs4mHrC1uDw4OVZlvwDDZb9pWMzW0kOrzhj1iI6sZ4D9k5fYQIdzBqB7aOqw==}
+    peerDependencies:
+      vue: 3.6.0-beta.9
+
   '@vue/shared@3.5.30':
     resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
+
+  '@vue/shared@3.6.0-beta.9':
+    resolution: {integrity: sha512-nY6DXeelJsmveeNk5YZYGd8q0ulWXACL8Qs/qvkPC4HQkyhPgf+Ja00AkG2hYsEI8Uixia2UpQl4CbObzw0hag==}
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -4351,6 +4391,14 @@ packages:
       typescript:
         optional: true
 
+  vue@3.6.0-beta.9:
+    resolution: {integrity: sha512-K/+HT52OAZvaNDDMvT+Lfk36e/97PsyJyDWXM0FDfLQKGbEDXsd4pSQz+BJViGssLcltQLSTlSqQlZ6fkGo5CA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -4778,10 +4826,10 @@ snapshots:
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
 
-  '@fortawesome/vue-fontawesome@3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.5.30(typescript@5.9.3))':
+  '@fortawesome/vue-fontawesome@3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.6.0-beta.9(typescript@5.9.3))':
     dependencies:
       '@fortawesome/fontawesome-svg-core': 6.7.2
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.6.0-beta.9(typescript@5.9.3)
 
   '@ioredis/commands@1.5.1': {}
 
@@ -6057,10 +6105,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.6.0-beta.9':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/shared': 3.6.0-beta.9
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.30':
     dependencies:
       '@vue/compiler-core': 3.5.30
       '@vue/shared': 3.5.30
+
+  '@vue/compiler-dom@3.6.0-beta.9':
+    dependencies:
+      '@vue/compiler-core': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.9
 
   '@vue/compiler-sfc@3.5.30':
     dependencies:
@@ -6074,10 +6135,36 @@ snapshots:
       postcss: 8.5.8
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.6.0-beta.9':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/compiler-core': 3.6.0-beta.9
+      '@vue/compiler-dom': 3.6.0-beta.9
+      '@vue/compiler-ssr': 3.6.0-beta.9
+      '@vue/compiler-vapor': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.9
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.8
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.30':
     dependencies:
       '@vue/compiler-dom': 3.5.30
       '@vue/shared': 3.5.30
+
+  '@vue/compiler-ssr@3.6.0-beta.9':
+    dependencies:
+      '@vue/compiler-dom': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.9
+
+  '@vue/compiler-vapor@3.6.0-beta.9':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/compiler-dom': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.9
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
 
   '@vue/devtools-api@8.1.1':
     dependencies:
@@ -6112,10 +6199,19 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.30
 
+  '@vue/reactivity@3.6.0-beta.9':
+    dependencies:
+      '@vue/shared': 3.6.0-beta.9
+
   '@vue/runtime-core@3.5.30':
     dependencies:
       '@vue/reactivity': 3.5.30
       '@vue/shared': 3.5.30
+
+  '@vue/runtime-core@3.6.0-beta.9':
+    dependencies:
+      '@vue/reactivity': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.9
 
   '@vue/runtime-dom@3.5.30':
     dependencies:
@@ -6124,13 +6220,34 @@ snapshots:
       '@vue/shared': 3.5.30
       csstype: 3.2.3
 
+  '@vue/runtime-dom@3.6.0-beta.9':
+    dependencies:
+      '@vue/reactivity': 3.6.0-beta.9
+      '@vue/runtime-core': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.9
+      csstype: 3.2.3
+
+  '@vue/runtime-vapor@3.6.0-beta.9(@vue/runtime-dom@3.6.0-beta.9)':
+    dependencies:
+      '@vue/reactivity': 3.6.0-beta.9
+      '@vue/runtime-dom': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.9
+
   '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.30
       '@vue/shared': 3.5.30
       vue: 3.5.30(typescript@5.9.3)
 
+  '@vue/server-renderer@3.6.0-beta.9(vue@3.6.0-beta.9(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.9
+      vue: 3.6.0-beta.9(typescript@5.9.3)
+
   '@vue/shared@3.5.30': {}
+
+  '@vue/shared@3.6.0-beta.9': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
@@ -8821,6 +8938,17 @@ snapshots:
       '@vue/runtime-dom': 3.5.30
       '@vue/server-renderer': 3.5.30(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
+    optionalDependencies:
+      typescript: 5.9.3
+
+  vue@3.6.0-beta.9(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.6.0-beta.9
+      '@vue/compiler-sfc': 3.6.0-beta.9
+      '@vue/runtime-dom': 3.6.0-beta.9
+      '@vue/runtime-vapor': 3.6.0-beta.9(@vue/runtime-dom@3.6.0-beta.9)
+      '@vue/server-renderer': 3.6.0-beta.9(vue@3.6.0-beta.9(typescript@5.9.3))
+      '@vue/shared': 3.6.0-beta.9
     optionalDependencies:
       typescript: 5.9.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@20.19.37)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.57.0(oxlint-tsgolint@0.17.3))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3)
     devDependencies:
       '@nuxt/test-utils':
-        specifier: ^3.20.0
-        version: 3.23.0(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.37)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+        specifier: ^4.0.0
+        version: 4.0.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)))
       '@vue/language-core':
         specifier: ^3.2.6
         version: 3.2.6
@@ -46,8 +46,8 @@ importers:
         specifier: ^2.4.6
         version: 2.4.6
       happy-dom:
-        specifier: ^18.0.1
-        version: 18.0.1
+        specifier: ^20.8.9
+        version: 20.8.9
       sass-embedded:
         specifier: ^1.89.0
         version: 1.98.0
@@ -56,10 +56,10 @@ importers:
         version: 5.9.3
       vite-plus:
         specifier: ^0.1.14
-        version: 0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(happy-dom@18.0.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3)
+        version: 0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.37)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -201,11 +201,17 @@ packages:
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
 
+  '@clack/core@1.0.0':
+    resolution: {integrity: sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ==}
+
   '@clack/core@1.0.0-alpha.7':
     resolution: {integrity: sha512-3vdh6Ar09D14rVxJZIm3VQJkU+ZOKKT5I5cC0cOVazy70CNyYYjiwRj9unwalhESndgxx6bGc/m6Hhs4EKF5XQ==}
 
   '@clack/core@1.1.0':
     resolution: {integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==}
+
+  '@clack/prompts@1.0.0':
+    resolution: {integrity: sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A==}
 
   '@clack/prompts@1.0.0-alpha.9':
     resolution: {integrity: sha512-sKs0UjiHFWvry4SiRfBi5Qnj0C/6AYx8aKkFPZQSuUZXgAram25ZDmhQmP7vj1aFyLpfHWtLQjWvOvcat0TOLg==}
@@ -484,6 +490,11 @@ packages:
   '@nuxt/devalue@2.0.2':
     resolution: {integrity: sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==}
 
+  '@nuxt/devtools-kit@2.7.0':
+    resolution: {integrity: sha512-MIJdah6CF6YOW2GhfKnb8Sivu6HpcQheqdjOlZqShBr+1DyjtKQbAKSCAyKPaoIzZP4QOo2SmTFV6aN8jBeEIQ==}
+    peerDependencies:
+      vite: '>=6.0'
+
   '@nuxt/devtools-kit@3.2.4':
     resolution: {integrity: sha512-Yxy2Xgmq5hf3dQy983V0xh0OJV2mYwRZz9eVIGc3EaribdFGPDNGMMbYqX9qCty3Pbxn/bCF3J0UyPaNlHVayQ==}
     peerDependencies:
@@ -549,6 +560,42 @@ packages:
       jsdom: '*'
       playwright-core: ^1.43.1
       vitest: ^3.2.0
+    peerDependenciesMeta:
+      '@cucumber/cucumber':
+        optional: true
+      '@jest/globals':
+        optional: true
+      '@playwright/test':
+        optional: true
+      '@testing-library/vue':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      '@vue/test-utils':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright-core:
+        optional: true
+      vitest:
+        optional: true
+
+  '@nuxt/test-utils@4.0.0':
+    resolution: {integrity: sha512-QJfyCiqYxflUKA5xlEGuXdDApTBhJxoPXxYePIDtA90hkmKbhYs/mrMM+Bi9LiUrI/cCJOPRyIx9jOzhMvTIgg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@cucumber/cucumber': '>=11.0.0'
+      '@jest/globals': '>=30.0.0'
+      '@playwright/test': ^1.43.1
+      '@testing-library/vue': ^8.0.1
+      '@vitest/ui': '*'
+      '@vue/test-utils': ^2.4.2
+      happy-dom: '>=20.0.11'
+      jsdom: '>=27.4.0'
+      playwright-core: ^1.43.1
+      vitest: ^4.0.2
     peerDependenciesMeta:
       '@cucumber/cucumber':
         optional: true
@@ -1561,6 +1608,9 @@ packages:
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@unhead/vue@2.1.12':
     resolution: {integrity: sha512-zEWqg0nZM8acpuTZE40wkeUl8AhIe0tU0OkilVi1D4fmVjACrwoh5HP6aNqJ8kUnKsoy6D+R3Vi/O+fmdNGO7g==}
     peerDependencies:
@@ -1588,34 +1638,34 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   '@voidzero-dev/vite-plus-core@0.1.14':
     resolution: {integrity: sha512-CCWzdkfW0fo0cQNlIsYp5fOuH2IwKuPZEb2UY2Z8gXcp5pG74A82H2Pthj0heAuvYTAnfT7kEC6zM+RbiBgQbg==}
@@ -2058,13 +2108,9 @@ packages:
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -2276,10 +2322,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -2617,6 +2659,15 @@ packages:
   h3@1.15.10:
     resolution: {integrity: sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==}
 
+  h3@2.0.1-rc.11:
+    resolution: {integrity: sha512-2myzjCqy32c1As9TjZW9fNZXtLqNedjFSrdFy2AjFBQQ3LzrnGoDdFDYfC0tV2e4vcyfJ2Sfo/F6NQhO2Ly/Mw==}
+    engines: {node: '>=20.11.1'}
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
   h3@2.0.1-rc.19:
     resolution: {integrity: sha512-47er/mh8eGA7+0nvNUloalj+yTJ1ku8M0BVzA2I1ZHSlpfbUNdBK4LpWztfH7TwW6kuhF8MfAvl0AwB+X9B+2w==}
     engines: {node: '>=20.11.1'}
@@ -2627,8 +2678,8 @@ packages:
       crossws:
         optional: true
 
-  happy-dom@18.0.1:
-    resolution: {integrity: sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==}
+  happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -2931,9 +2982,6 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -3245,10 +3293,6 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
-
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -3555,6 +3599,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rou3@0.7.12:
+    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
@@ -3794,6 +3841,11 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  srvx@0.10.1:
+    resolution: {integrity: sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   srvx@0.11.13:
     resolution: {integrity: sha512-oknN6qduuMPafxKtHucUeG32Q963pjriA5g3/Bl05cwEsUe5VVbIU4qR9LrALHbipSCyBe+VmfDGGydqazDRkw==}
     engines: {node: '>=20.16.0'}
@@ -3921,9 +3973,6 @@ packages:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -3932,20 +3981,12 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -4128,11 +4169,6 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite-node@5.3.0:
     resolution: {integrity: sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4239,26 +4275,33 @@ packages:
   vitest-environment-nuxt@1.0.1:
     resolution: {integrity: sha512-eBCwtIQriXW5/M49FjqNKfnlJYlG2LWMSNFsRVKomc8CaMqmhQPBS5LZ9DlgYL9T8xIVsiA6RZn2lk7vxov3Ow==}
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
         optional: true
       '@vitest/ui':
         optional: true
@@ -4578,6 +4621,11 @@ snapshots:
 
   '@bufbuild/protobuf@2.11.0': {}
 
+  '@clack/core@1.0.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@clack/core@1.0.0-alpha.7':
     dependencies:
       picocolors: 1.1.1
@@ -4585,6 +4633,12 @@ snapshots:
 
   '@clack/core@1.1.0':
     dependencies:
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.0.0':
+    dependencies:
+      '@clack/core': 1.0.0
+      picocolors: 1.1.1
       sisteransi: 1.0.5
 
   '@clack/prompts@1.0.0-alpha.9':
@@ -4848,6 +4902,14 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
+  '@nuxt/devtools-kit@2.7.0(magicast@0.5.2)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))':
+    dependencies:
+      '@nuxt/kit': 3.21.2(magicast@0.5.2)
+      execa: 8.0.1
+      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - magicast
+
   '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
@@ -5045,7 +5107,7 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/test-utils@3.23.0(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.37)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))':
+  '@nuxt/test-utils@3.23.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(typescript@5.9.3)(vitest@4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)))':
     dependencies:
       '@clack/prompts': 1.0.0-alpha.9
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
@@ -5073,16 +5135,57 @@ snapshots:
       tinyexec: 1.0.4
       ufo: 1.6.3
       unplugin: 2.3.11
-      vitest-environment-nuxt: 1.0.1(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.37)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+      vitest-environment-nuxt: 1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(typescript@5.9.3)(vitest@4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)))
       vue: 3.5.30(typescript@5.9.3)
     optionalDependencies:
       '@vue/test-utils': 2.4.6
-      happy-dom: 18.0.1
-      vitest: 3.2.4(@types/node@20.19.37)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
+      happy-dom: 20.8.9
+      vitest: 4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - crossws
       - magicast
       - typescript
+
+  '@nuxt/test-utils@4.0.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)))':
+    dependencies:
+      '@clack/prompts': 1.0.0
+      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+      '@nuxt/kit': 3.21.2(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.5.2)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      estree-walker: 3.0.3
+      exsolve: 1.0.8
+      fake-indexeddb: 6.2.5
+      get-port-please: 3.2.0
+      h3: 1.15.10
+      h3-next: h3@2.0.1-rc.11
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      node-fetch-native: 1.6.7
+      node-mock-http: 1.0.4
+      nypm: 0.6.5
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      radix3: 1.1.2
+      scule: 1.3.0
+      std-env: 3.10.0
+      tinyexec: 1.0.4
+      ufo: 1.6.3
+      unplugin: 3.0.0
+      vitest-environment-nuxt: 1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(typescript@5.9.3)(vitest@4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)))
+      vue: 3.5.30(typescript@5.9.3)
+    optionalDependencies:
+      '@vue/test-utils': 2.4.6
+      happy-dom: 20.8.9
+      vitest: 4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - crossws
+      - magicast
+      - typescript
+      - vite
 
   '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@20.19.37)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@20.19.37)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.57.0(oxlint-tsgolint@0.17.3))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3))(oxlint@1.57.0(oxlint-tsgolint@0.17.3))(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
@@ -5724,6 +5827,10 @@ snapshots:
 
   '@types/whatwg-mimetype@3.0.2': {}
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.37
+
   '@unhead/vue@2.1.12(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       hookable: 6.1.0
@@ -5769,47 +5876,46 @@ snapshots:
       vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.2':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.1.2':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.1.2':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.2
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.2': {}
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@voidzero-dev/vite-plus-core@0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
@@ -5846,7 +5952,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.14':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(happy-dom@18.0.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -5864,7 +5970,7 @@ snapshots:
       ws: 8.20.0
     optionalDependencies:
       '@types/node': 20.19.37
-      happy-dom: 18.0.1
+      happy-dom: 20.8.9
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -6251,15 +6357,7 @@ snapshots:
 
   caniuse-lite@1.0.30001781: {}
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
-
-  check-error@2.1.3: {}
+  chai@6.2.2: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -6470,8 +6568,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  deep-eql@5.0.2: {}
 
   deepmerge@4.3.1: {}
 
@@ -6802,16 +6898,27 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
+  h3@2.0.1-rc.11:
+    dependencies:
+      rou3: 0.7.12
+      srvx: 0.10.1
+
   h3@2.0.1-rc.19:
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.13
 
-  happy-dom@18.0.1:
+  happy-dom@20.8.9:
     dependencies:
       '@types/node': 20.19.37
       '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
       whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -7075,8 +7182,6 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash@4.17.23: {}
-
-  loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
 
@@ -7658,8 +7763,6 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pathval@2.0.1: {}
-
   perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
@@ -7966,6 +8069,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
+  rou3@0.7.12: {}
+
   rou3@0.8.1: {}
 
   run-applescript@7.1.0: {}
@@ -8192,6 +8297,8 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  srvx@0.10.1: {}
+
   srvx@0.11.13: {}
 
   stackback@0.0.2: {}
@@ -8334,8 +8441,6 @@ snapshots:
 
   tinyclip@0.1.12: {}
 
-  tinyexec@0.3.2: {}
-
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
@@ -8343,13 +8448,9 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
   tinypool@2.1.0: {}
 
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8499,27 +8600,6 @@ snapshots:
     dependencies:
       vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
 
-  vite-node@3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@5.3.0(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
@@ -8583,11 +8663,11 @@ snapshots:
       vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
       vue: 3.5.30(typescript@5.9.3)
 
-  vite-plus@0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(happy-dom@18.0.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3):
+  vite-plus@0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@oxc-project/types': 0.122.0
       '@voidzero-dev/vite-plus-core': 0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(happy-dom@18.0.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.14(@types/node@20.19.37)(esbuild@0.27.4)(happy-dom@20.8.9)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3)
       cac: 7.0.0
       cross-spawn: 7.0.6
       oxfmt: 0.42.0
@@ -8649,9 +8729,9 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.3
 
-  vitest-environment-nuxt@1.0.1(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.37)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)):
+  vitest-environment-nuxt@1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(typescript@5.9.3)(vitest@4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))):
     dependencies:
-      '@nuxt/test-utils': 3.23.0(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.5.2)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.37)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+      '@nuxt/test-utils': 3.23.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(typescript@5.9.3)(vitest@4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -8667,47 +8747,33 @@ snapshots:
       - typescript
       - vitest
 
-  vitest@3.2.4(@types/node@20.19.37)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3):
+  vitest@4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
       vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37
-      happy-dom: 18.0.1
+      happy-dom: 20.8.9
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vscode-uri@3.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 6.7.2
       '@fortawesome/vue-fontawesome':
         specifier: ^3.0.8
-        version: 3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.5.30(typescript@5.9.3))
       contentful:
         specifier: ^11.5.20
         version: 11.12.0
@@ -61,11 +61,11 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.5.30
+        version: 3.5.30(typescript@5.9.3)
       vue-router:
         specifier: 5.0.4
-        version: 5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.5.30(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -1843,29 +1843,14 @@ packages:
   '@vue/compiler-core@3.5.30':
     resolution: {integrity: sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==}
 
-  '@vue/compiler-core@3.6.0-beta.1':
-    resolution: {integrity: sha512-Oiki36gKyoxc0pPnazo83coH6I4KTenCbhcMjALVo+vhz3cPVylo5Y5PyzX/u45IiMHc/25t492VB6CrFYKEgQ==}
-
   '@vue/compiler-dom@3.5.30':
     resolution: {integrity: sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==}
-
-  '@vue/compiler-dom@3.6.0-beta.1':
-    resolution: {integrity: sha512-6fbQSyjk6tdJO6UOvOtVl1BHw3CuzKSeNRU84LXvlyqm4K1LWJwKaceu5RZyi8+cFusuxtArpH6dwx9cPbejAg==}
 
   '@vue/compiler-sfc@3.5.30':
     resolution: {integrity: sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==}
 
-  '@vue/compiler-sfc@3.6.0-beta.1':
-    resolution: {integrity: sha512-ntC1t5lbbbA5122ONOVQiQVXgDwJQ/xkB/KGUpP7e59An9m/I2CONRtAEB9wB6QQmMMP4ThoOuRH9+t2o6dqjQ==}
-
   '@vue/compiler-ssr@3.5.30':
     resolution: {integrity: sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==}
-
-  '@vue/compiler-ssr@3.6.0-beta.1':
-    resolution: {integrity: sha512-8hvHjcNPcKYto87/vRCxFFCp6FEg9HAA/oQHQ6DZQe70xnJguCPvYhh+e59HuywN4E68RBOIPC9IYTXenTaIWA==}
-
-  '@vue/compiler-vapor@3.6.0-beta.1':
-    resolution: {integrity: sha512-NW1FMqjag5fPVf8uK199gw5qFzPBNc4OghchSffS7D2UOs5QMzIpC4XevGA5DeGEuxhpuG9ckisGN2r9BsnTzQ==}
 
   '@vue/devtools-api@8.1.1':
     resolution: {integrity: sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==}
@@ -1887,41 +1872,19 @@ packages:
   '@vue/reactivity@3.5.30':
     resolution: {integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==}
 
-  '@vue/reactivity@3.6.0-beta.1':
-    resolution: {integrity: sha512-IbmZR0/UVlfRgDE8oVERx8pmYpG0CtE8CWfkdrnjnQckuCoImXCn7W9HiShzmmDNus371hGw6cXCctjQL7hkZw==}
-
   '@vue/runtime-core@3.5.30':
     resolution: {integrity: sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==}
 
-  '@vue/runtime-core@3.6.0-beta.1':
-    resolution: {integrity: sha512-UtZCF+rPSPsKQUTOwB3EHd2y8mY9lD6nr78Gt/fqwnSdxaXY0ksbhc1Q9BjHZPaDMpn8NKzQKlMXf/h1w8VMkg==}
-
   '@vue/runtime-dom@3.5.30':
     resolution: {integrity: sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==}
-
-  '@vue/runtime-dom@3.6.0-beta.1':
-    resolution: {integrity: sha512-+vv8WwxSFzXzjXWvZ92q1ec13fp+RBtAiOTu7M5dWRLqsDEHuVnuzmPB5O+gmiNU0YViLEXP5c/+gDCP3y5yUw==}
-
-  '@vue/runtime-vapor@3.6.0-beta.1':
-    resolution: {integrity: sha512-XVethfYDcowADbaq1XVEq6BAqnpKgc/75WL5xjy2ChwEB9slMa7B2PBpGSGwvEKKsNyAapYQoa/af5fyogaSlw==}
-    peerDependencies:
-      '@vue/runtime-dom': 3.6.0-beta.1
 
   '@vue/server-renderer@3.5.30':
     resolution: {integrity: sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==}
     peerDependencies:
       vue: 3.5.30
 
-  '@vue/server-renderer@3.6.0-beta.1':
-    resolution: {integrity: sha512-MpjAiqP/4JTDMswoDSWyS1PCDzR9+ud2aRAOhvtlpnsuNFLwYbf8tNOiPd3x3gty8ghWYMyKCP4isQHNcPRmLA==}
-    peerDependencies:
-      vue: 3.6.0-beta.1
-
   '@vue/shared@3.5.30':
     resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
-
-  '@vue/shared@3.6.0-beta.1':
-    resolution: {integrity: sha512-M+JCCPvuXgRGkgRYQ9LISH8eJXlQgz862OBtO2n7Ef2cyz+DgLQTGfZoNzf3WbVnNUP9/5x7/O0P1ED42IDCCw==}
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -4394,14 +4357,6 @@ packages:
       typescript:
         optional: true
 
-  vue@3.6.0-beta.1:
-    resolution: {integrity: sha512-z2VKatkexJ9XZ/eYbUUQaitaYC1MpTtE+7zESy7bBvfcExlF5ubBmCB001I6GznEw4vRR1WMZbDqT482QJEJHw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -4829,10 +4784,10 @@ snapshots:
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
 
-  '@fortawesome/vue-fontawesome@3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@fortawesome/vue-fontawesome@3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@fortawesome/fontawesome-svg-core': 6.7.2
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.5.30(typescript@5.9.3)
 
   '@ioredis/commands@1.5.1': {}
 
@@ -6071,16 +6026,6 @@ snapshots:
     optionalDependencies:
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vue-macros/common@3.1.2(vue@3.6.0-beta.1(typescript@5.9.3))':
-    dependencies:
-      '@vue/compiler-sfc': 3.5.30
-      ast-kit: 2.2.0
-      local-pkg: 1.1.2
-      magic-string-ast: 1.0.3
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      vue: 3.6.0-beta.1(typescript@5.9.3)
-
   '@vue/babel-helper-vue-transform-on@2.0.1': {}
 
   '@vue/babel-plugin-jsx@2.0.1(@babel/core@7.29.0)':
@@ -6118,23 +6063,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.6.0-beta.1':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/shared': 3.6.0-beta.1
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
   '@vue/compiler-dom@3.5.30':
     dependencies:
       '@vue/compiler-core': 3.5.30
       '@vue/shared': 3.5.30
-
-  '@vue/compiler-dom@3.6.0-beta.1':
-    dependencies:
-      '@vue/compiler-core': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
 
   '@vue/compiler-sfc@3.5.30':
     dependencies:
@@ -6148,36 +6080,10 @@ snapshots:
       postcss: 8.5.8
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.6.0-beta.1':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/compiler-core': 3.6.0-beta.1
-      '@vue/compiler-dom': 3.6.0-beta.1
-      '@vue/compiler-ssr': 3.6.0-beta.1
-      '@vue/compiler-vapor': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-      postcss: 8.5.8
-      source-map-js: 1.2.1
-
   '@vue/compiler-ssr@3.5.30':
     dependencies:
       '@vue/compiler-dom': 3.5.30
       '@vue/shared': 3.5.30
-
-  '@vue/compiler-ssr@3.6.0-beta.1':
-    dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
-
-  '@vue/compiler-vapor@3.6.0-beta.1':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/compiler-dom': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
 
   '@vue/devtools-api@8.1.1':
     dependencies:
@@ -6212,19 +6118,10 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.30
 
-  '@vue/reactivity@3.6.0-beta.1':
-    dependencies:
-      '@vue/shared': 3.6.0-beta.1
-
   '@vue/runtime-core@3.5.30':
     dependencies:
       '@vue/reactivity': 3.5.30
       '@vue/shared': 3.5.30
-
-  '@vue/runtime-core@3.6.0-beta.1':
-    dependencies:
-      '@vue/reactivity': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
 
   '@vue/runtime-dom@3.5.30':
     dependencies:
@@ -6233,34 +6130,13 @@ snapshots:
       '@vue/shared': 3.5.30
       csstype: 3.2.3
 
-  '@vue/runtime-dom@3.6.0-beta.1':
-    dependencies:
-      '@vue/reactivity': 3.6.0-beta.1
-      '@vue/runtime-core': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
-      csstype: 3.2.3
-
-  '@vue/runtime-vapor@3.6.0-beta.1(@vue/runtime-dom@3.6.0-beta.1)':
-    dependencies:
-      '@vue/reactivity': 3.6.0-beta.1
-      '@vue/runtime-dom': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
-
   '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.30
       '@vue/shared': 3.5.30
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vue/server-renderer@3.6.0-beta.1(vue@3.6.0-beta.1(typescript@5.9.3))':
-    dependencies:
-      '@vue/compiler-ssr': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
-      vue: 3.6.0-beta.1(typescript@5.9.3)
-
   '@vue/shared@3.5.30': {}
-
-  '@vue/shared@3.6.0-beta.1': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
@@ -8938,29 +8814,6 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.30
 
-  vue-router@5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.6.0-beta.1(typescript@5.9.3)):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@vue-macros/common': 3.1.2(vue@3.6.0-beta.1(typescript@5.9.3))
-      '@vue/devtools-api': 8.1.1
-      ast-walker-scope: 0.8.3
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.15
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.6.0-beta.1(typescript@5.9.3)
-      yaml: 2.8.3
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.30
-
   vue-tsc@3.2.6(typescript@5.9.3):
     dependencies:
       '@volar/typescript': 2.4.28
@@ -8974,17 +8827,6 @@ snapshots:
       '@vue/runtime-dom': 3.5.30
       '@vue/server-renderer': 3.5.30(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-    optionalDependencies:
-      typescript: 5.9.3
-
-  vue@3.6.0-beta.1(typescript@5.9.3):
-    dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.1
-      '@vue/compiler-sfc': 3.6.0-beta.1
-      '@vue/runtime-dom': 3.6.0-beta.1
-      '@vue/runtime-vapor': 3.6.0-beta.1(@vue/runtime-dom@3.6.0-beta.1)
-      '@vue/server-renderer': 3.6.0-beta.1(vue@3.6.0-beta.1(typescript@5.9.3))
-      '@vue/shared': 3.6.0-beta.1
     optionalDependencies:
       typescript: 5.9.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 6.7.2
       '@fortawesome/vue-fontawesome':
         specifier: ^3.0.8
-        version: 3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.6.0-beta.9(typescript@5.9.3))
+        version: 3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.6.0-beta.1(typescript@5.9.3))
       contentful:
         specifier: ^11.5.20
         version: 11.12.0
@@ -61,11 +61,11 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.1)(yaml@2.8.3))
       vue:
-        specifier: 3.6.0-beta.9
-        version: 3.6.0-beta.9(typescript@5.9.3)
+        specifier: 3.6.0-beta.1
+        version: 3.6.0-beta.1(typescript@5.9.3)
       vue-router:
         specifier: 5.0.4
-        version: 5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.6.0-beta.9(typescript@5.9.3))
+        version: 5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.6.0-beta.1(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -1843,29 +1843,29 @@ packages:
   '@vue/compiler-core@3.5.30':
     resolution: {integrity: sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==}
 
-  '@vue/compiler-core@3.6.0-beta.9':
-    resolution: {integrity: sha512-/qlfk4cbU//tgdwWeAbl4kBvH5ZocjJ6CMGigzRKk1So/0jl6kRpFxVbc6oNsYYH6Xj28ByA+msAes1FjExejg==}
+  '@vue/compiler-core@3.6.0-beta.1':
+    resolution: {integrity: sha512-Oiki36gKyoxc0pPnazo83coH6I4KTenCbhcMjALVo+vhz3cPVylo5Y5PyzX/u45IiMHc/25t492VB6CrFYKEgQ==}
 
   '@vue/compiler-dom@3.5.30':
     resolution: {integrity: sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==}
 
-  '@vue/compiler-dom@3.6.0-beta.9':
-    resolution: {integrity: sha512-Bh2h+Co2Vl85jhNjR+yBU1oIujqQ3XIhF7FzODBStvp8yn2WvsXmm5QlvnE7q+smJkfglTbfFcaou8fjR0Y4ag==}
+  '@vue/compiler-dom@3.6.0-beta.1':
+    resolution: {integrity: sha512-6fbQSyjk6tdJO6UOvOtVl1BHw3CuzKSeNRU84LXvlyqm4K1LWJwKaceu5RZyi8+cFusuxtArpH6dwx9cPbejAg==}
 
   '@vue/compiler-sfc@3.5.30':
     resolution: {integrity: sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==}
 
-  '@vue/compiler-sfc@3.6.0-beta.9':
-    resolution: {integrity: sha512-13MwFqrIN+AFxR5uT88WYaMTxXycpNNI75sIllz5blXbFaBsDfiegQZj10Pj5G3cgH7WFy2Trs1rTlXrmSgG/w==}
+  '@vue/compiler-sfc@3.6.0-beta.1':
+    resolution: {integrity: sha512-ntC1t5lbbbA5122ONOVQiQVXgDwJQ/xkB/KGUpP7e59An9m/I2CONRtAEB9wB6QQmMMP4ThoOuRH9+t2o6dqjQ==}
 
   '@vue/compiler-ssr@3.5.30':
     resolution: {integrity: sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==}
 
-  '@vue/compiler-ssr@3.6.0-beta.9':
-    resolution: {integrity: sha512-ufzHVMJoMz7QzMFop03a8KpWAWUh4hiof/tJXvxiDClIFUY7P5OrKk644fV9qlWgTP7V+eQvA7kVSEVRUgYjvA==}
+  '@vue/compiler-ssr@3.6.0-beta.1':
+    resolution: {integrity: sha512-8hvHjcNPcKYto87/vRCxFFCp6FEg9HAA/oQHQ6DZQe70xnJguCPvYhh+e59HuywN4E68RBOIPC9IYTXenTaIWA==}
 
-  '@vue/compiler-vapor@3.6.0-beta.9':
-    resolution: {integrity: sha512-1WWCcRjkH/scYJ8dsjNp8+NDf4f9SwQgOcd4Hbl5p0srNPflqrQYvAaJh4N2Szxj5FdkXw2t5uiK35TpFM5uKA==}
+  '@vue/compiler-vapor@3.6.0-beta.1':
+    resolution: {integrity: sha512-NW1FMqjag5fPVf8uK199gw5qFzPBNc4OghchSffS7D2UOs5QMzIpC4XevGA5DeGEuxhpuG9ckisGN2r9BsnTzQ==}
 
   '@vue/devtools-api@8.1.1':
     resolution: {integrity: sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==}
@@ -1887,41 +1887,41 @@ packages:
   '@vue/reactivity@3.5.30':
     resolution: {integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==}
 
-  '@vue/reactivity@3.6.0-beta.9':
-    resolution: {integrity: sha512-Mo0GjZB/q7LUJplPjBdKqAAk4mawkzvnk2nNf9CEetp4RQJP5/e/DdmgjYBsr/+UVX5ShasCalwdyknuuIepdw==}
+  '@vue/reactivity@3.6.0-beta.1':
+    resolution: {integrity: sha512-IbmZR0/UVlfRgDE8oVERx8pmYpG0CtE8CWfkdrnjnQckuCoImXCn7W9HiShzmmDNus371hGw6cXCctjQL7hkZw==}
 
   '@vue/runtime-core@3.5.30':
     resolution: {integrity: sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==}
 
-  '@vue/runtime-core@3.6.0-beta.9':
-    resolution: {integrity: sha512-IPbO/cmw0BSHec17fSE8Mbtv0UFBiiiGhvlUGiJWTa/eOlbiO+mZ9/PRRUQ+v/tkKuwFSzKye7KOKj5aFO1dgQ==}
+  '@vue/runtime-core@3.6.0-beta.1':
+    resolution: {integrity: sha512-UtZCF+rPSPsKQUTOwB3EHd2y8mY9lD6nr78Gt/fqwnSdxaXY0ksbhc1Q9BjHZPaDMpn8NKzQKlMXf/h1w8VMkg==}
 
   '@vue/runtime-dom@3.5.30':
     resolution: {integrity: sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==}
 
-  '@vue/runtime-dom@3.6.0-beta.9':
-    resolution: {integrity: sha512-+WV0V1s/uf9iFwZt41lOtJHbIqKyYdEO+nmW0UOnQLjG9ELz6rKuZ92fEim6NPcKCsucv2BoB1mK9T82khYqgg==}
+  '@vue/runtime-dom@3.6.0-beta.1':
+    resolution: {integrity: sha512-+vv8WwxSFzXzjXWvZ92q1ec13fp+RBtAiOTu7M5dWRLqsDEHuVnuzmPB5O+gmiNU0YViLEXP5c/+gDCP3y5yUw==}
 
-  '@vue/runtime-vapor@3.6.0-beta.9':
-    resolution: {integrity: sha512-UlAziGF77byUa84RgkIdCT4bleZbB4UvQvmxdGHFfscGylSABBZHAMR8WJIwBsy1MsZnlpRSSeDAYB20RicrhQ==}
+  '@vue/runtime-vapor@3.6.0-beta.1':
+    resolution: {integrity: sha512-XVethfYDcowADbaq1XVEq6BAqnpKgc/75WL5xjy2ChwEB9slMa7B2PBpGSGwvEKKsNyAapYQoa/af5fyogaSlw==}
     peerDependencies:
-      '@vue/runtime-dom': 3.6.0-beta.9
+      '@vue/runtime-dom': 3.6.0-beta.1
 
   '@vue/server-renderer@3.5.30':
     resolution: {integrity: sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==}
     peerDependencies:
       vue: 3.5.30
 
-  '@vue/server-renderer@3.6.0-beta.9':
-    resolution: {integrity: sha512-qyz37g6pmwHvtXbe7CWKm5+VTmCs4mHrC1uDw4OVZlvwDDZb9pWMzW0kOrzhj1iI6sZ4D9k5fYQIdzBqB7aOqw==}
+  '@vue/server-renderer@3.6.0-beta.1':
+    resolution: {integrity: sha512-MpjAiqP/4JTDMswoDSWyS1PCDzR9+ud2aRAOhvtlpnsuNFLwYbf8tNOiPd3x3gty8ghWYMyKCP4isQHNcPRmLA==}
     peerDependencies:
-      vue: 3.6.0-beta.9
+      vue: 3.6.0-beta.1
 
   '@vue/shared@3.5.30':
     resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
 
-  '@vue/shared@3.6.0-beta.9':
-    resolution: {integrity: sha512-nY6DXeelJsmveeNk5YZYGd8q0ulWXACL8Qs/qvkPC4HQkyhPgf+Ja00AkG2hYsEI8Uixia2UpQl4CbObzw0hag==}
+  '@vue/shared@3.6.0-beta.1':
+    resolution: {integrity: sha512-M+JCCPvuXgRGkgRYQ9LISH8eJXlQgz862OBtO2n7Ef2cyz+DgLQTGfZoNzf3WbVnNUP9/5x7/O0P1ED42IDCCw==}
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -4394,8 +4394,8 @@ packages:
       typescript:
         optional: true
 
-  vue@3.6.0-beta.9:
-    resolution: {integrity: sha512-K/+HT52OAZvaNDDMvT+Lfk36e/97PsyJyDWXM0FDfLQKGbEDXsd4pSQz+BJViGssLcltQLSTlSqQlZ6fkGo5CA==}
+  vue@3.6.0-beta.1:
+    resolution: {integrity: sha512-z2VKatkexJ9XZ/eYbUUQaitaYC1MpTtE+7zESy7bBvfcExlF5ubBmCB001I6GznEw4vRR1WMZbDqT482QJEJHw==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -4829,10 +4829,10 @@ snapshots:
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
 
-  '@fortawesome/vue-fontawesome@3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.6.0-beta.9(typescript@5.9.3))':
+  '@fortawesome/vue-fontawesome@3.1.3(@fortawesome/fontawesome-svg-core@6.7.2)(vue@3.6.0-beta.1(typescript@5.9.3))':
     dependencies:
       '@fortawesome/fontawesome-svg-core': 6.7.2
-      vue: 3.6.0-beta.9(typescript@5.9.3)
+      vue: 3.6.0-beta.1(typescript@5.9.3)
 
   '@ioredis/commands@1.5.1': {}
 
@@ -6071,7 +6071,7 @@ snapshots:
     optionalDependencies:
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vue-macros/common@3.1.2(vue@3.6.0-beta.9(typescript@5.9.3))':
+  '@vue-macros/common@3.1.2(vue@3.6.0-beta.1(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.30
       ast-kit: 2.2.0
@@ -6079,7 +6079,7 @@ snapshots:
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.1
     optionalDependencies:
-      vue: 3.6.0-beta.9(typescript@5.9.3)
+      vue: 3.6.0-beta.1(typescript@5.9.3)
 
   '@vue/babel-helper-vue-transform-on@2.0.1': {}
 
@@ -6118,10 +6118,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.6.0-beta.9':
+  '@vue/compiler-core@3.6.0-beta.1':
     dependencies:
       '@babel/parser': 7.29.2
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.1
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -6131,10 +6131,10 @@ snapshots:
       '@vue/compiler-core': 3.5.30
       '@vue/shared': 3.5.30
 
-  '@vue/compiler-dom@3.6.0-beta.9':
+  '@vue/compiler-dom@3.6.0-beta.1':
     dependencies:
-      '@vue/compiler-core': 3.6.0-beta.9
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/compiler-core': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.1
 
   '@vue/compiler-sfc@3.5.30':
     dependencies:
@@ -6148,14 +6148,14 @@ snapshots:
       postcss: 8.5.8
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.6.0-beta.9':
+  '@vue/compiler-sfc@3.6.0-beta.1':
     dependencies:
       '@babel/parser': 7.29.2
-      '@vue/compiler-core': 3.6.0-beta.9
-      '@vue/compiler-dom': 3.6.0-beta.9
-      '@vue/compiler-ssr': 3.6.0-beta.9
-      '@vue/compiler-vapor': 3.6.0-beta.9
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/compiler-core': 3.6.0-beta.1
+      '@vue/compiler-dom': 3.6.0-beta.1
+      '@vue/compiler-ssr': 3.6.0-beta.1
+      '@vue/compiler-vapor': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.1
       estree-walker: 2.0.2
       magic-string: 0.30.21
       postcss: 8.5.8
@@ -6166,16 +6166,16 @@ snapshots:
       '@vue/compiler-dom': 3.5.30
       '@vue/shared': 3.5.30
 
-  '@vue/compiler-ssr@3.6.0-beta.9':
+  '@vue/compiler-ssr@3.6.0-beta.1':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.9
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/compiler-dom': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.1
 
-  '@vue/compiler-vapor@3.6.0-beta.9':
+  '@vue/compiler-vapor@3.6.0-beta.1':
     dependencies:
       '@babel/parser': 7.29.2
-      '@vue/compiler-dom': 3.6.0-beta.9
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/compiler-dom': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
@@ -6212,19 +6212,19 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.30
 
-  '@vue/reactivity@3.6.0-beta.9':
+  '@vue/reactivity@3.6.0-beta.1':
     dependencies:
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/shared': 3.6.0-beta.1
 
   '@vue/runtime-core@3.5.30':
     dependencies:
       '@vue/reactivity': 3.5.30
       '@vue/shared': 3.5.30
 
-  '@vue/runtime-core@3.6.0-beta.9':
+  '@vue/runtime-core@3.6.0-beta.1':
     dependencies:
-      '@vue/reactivity': 3.6.0-beta.9
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/reactivity': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.1
 
   '@vue/runtime-dom@3.5.30':
     dependencies:
@@ -6233,18 +6233,18 @@ snapshots:
       '@vue/shared': 3.5.30
       csstype: 3.2.3
 
-  '@vue/runtime-dom@3.6.0-beta.9':
+  '@vue/runtime-dom@3.6.0-beta.1':
     dependencies:
-      '@vue/reactivity': 3.6.0-beta.9
-      '@vue/runtime-core': 3.6.0-beta.9
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/reactivity': 3.6.0-beta.1
+      '@vue/runtime-core': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.1
       csstype: 3.2.3
 
-  '@vue/runtime-vapor@3.6.0-beta.9(@vue/runtime-dom@3.6.0-beta.9)':
+  '@vue/runtime-vapor@3.6.0-beta.1(@vue/runtime-dom@3.6.0-beta.1)':
     dependencies:
-      '@vue/reactivity': 3.6.0-beta.9
-      '@vue/runtime-dom': 3.6.0-beta.9
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/reactivity': 3.6.0-beta.1
+      '@vue/runtime-dom': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.1
 
   '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))':
     dependencies:
@@ -6252,15 +6252,15 @@ snapshots:
       '@vue/shared': 3.5.30
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vue/server-renderer@3.6.0-beta.9(vue@3.6.0-beta.9(typescript@5.9.3))':
+  '@vue/server-renderer@3.6.0-beta.1(vue@3.6.0-beta.1(typescript@5.9.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.6.0-beta.9
-      '@vue/shared': 3.6.0-beta.9
-      vue: 3.6.0-beta.9(typescript@5.9.3)
+      '@vue/compiler-ssr': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.1
+      vue: 3.6.0-beta.1(typescript@5.9.3)
 
   '@vue/shared@3.5.30': {}
 
-  '@vue/shared@3.6.0-beta.9': {}
+  '@vue/shared@3.6.0-beta.1': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
@@ -8938,10 +8938,10 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.30
 
-  vue-router@5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.6.0-beta.9(typescript@5.9.3)):
+  vue-router@5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.6.0-beta.1(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 7.29.1
-      '@vue-macros/common': 3.1.2(vue@3.6.0-beta.9(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.6.0-beta.1(typescript@5.9.3))
       '@vue/devtools-api': 8.1.1
       ast-walker-scope: 0.8.3
       chokidar: 5.0.0
@@ -8956,7 +8956,7 @@ snapshots:
       tinyglobby: 0.2.15
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
-      vue: 3.6.0-beta.9(typescript@5.9.3)
+      vue: 3.6.0-beta.1(typescript@5.9.3)
       yaml: 2.8.3
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.30
@@ -8977,14 +8977,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  vue@3.6.0-beta.9(typescript@5.9.3):
+  vue@3.6.0-beta.1(typescript@5.9.3):
     dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.9
-      '@vue/compiler-sfc': 3.6.0-beta.9
-      '@vue/runtime-dom': 3.6.0-beta.9
-      '@vue/runtime-vapor': 3.6.0-beta.9(@vue/runtime-dom@3.6.0-beta.9)
-      '@vue/server-renderer': 3.6.0-beta.9(vue@3.6.0-beta.9(typescript@5.9.3))
-      '@vue/shared': 3.6.0-beta.9
+      '@vue/compiler-dom': 3.6.0-beta.1
+      '@vue/compiler-sfc': 3.6.0-beta.1
+      '@vue/runtime-dom': 3.6.0-beta.1
+      '@vue/runtime-vapor': 3.6.0-beta.1(@vue/runtime-dom@3.6.0-beta.1)
+      '@vue/server-renderer': 3.6.0-beta.1(vue@3.6.0-beta.1(typescript@5.9.3))
+      '@vue/shared': 3.6.0-beta.1
     optionalDependencies:
       typescript: 5.9.3
 

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -1,3 +1,22 @@
+<script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+})
+
+defineProps<{
+  to?: string
+}>()
+
+const attrs = useAttrs()
+const emit = defineEmits<{
+  click: [event: MouseEvent]
+}>()
+
+const tagName = computed(() =>
+  typeof attrs.href === 'string' ? 'a' : 'button',
+)
+</script>
+
 <template>
   <NuxtLink
     v-if="to"
@@ -19,25 +38,6 @@
     <slot />
   </component>
 </template>
-
-<script setup lang="ts">
-defineOptions({
-  inheritAttrs: false,
-})
-
-defineProps<{
-  to?: string
-}>()
-
-const attrs = useAttrs()
-const emit = defineEmits<{
-  click: [event: MouseEvent]
-}>()
-
-const tagName = computed(() =>
-  typeof attrs.href === 'string' ? 'a' : 'button',
-)
-</script>
 
 <style lang="scss" scoped>
 .base-button {

--- a/src/components/HeadCircle.vue
+++ b/src/components/HeadCircle.vue
@@ -1,9 +1,3 @@
-<template>
-  <g :transform="transform">
-    <circle ref="shape" cx="0" cy="0" r="0" />
-  </g>
-</template>
-
 <script setup lang="ts">
 import { gsap, Power2 } from 'gsap'
 import { partsCreateTime, partsLeaveTime, type Parts } from '~/lib/head-visual'
@@ -49,6 +43,12 @@ onBeforeUnmount(() => {
   })
 })
 </script>
+
+<template>
+  <g :transform="transform">
+    <circle ref="shape" cx="0" cy="0" r="0" />
+  </g>
+</template>
 
 <style lang="scss" scoped>
 circle {

--- a/src/components/HeadCross.vue
+++ b/src/components/HeadCross.vue
@@ -1,12 +1,3 @@
-<template>
-  <g :transform="transform">
-    <polygon key="1" ref="shape1" :points="keyFrame1[0]" />
-    <polygon key="2" ref="shape2" :points="keyFrame2[0]" />
-    <polygon key="3" ref="shape3" :points="keyFrame3[0]" />
-    <polygon key="4" ref="shape4" :points="keyFrame4[0]" />
-  </g>
-</template>
-
 <script setup lang="ts">
 import { gsap, Power2 } from 'gsap'
 import { partsCreateTime, partsLeaveTime, type Parts } from '~/lib/head-visual'
@@ -98,6 +89,15 @@ onMounted(() => {
 
 onBeforeUnmount(animateOut)
 </script>
+
+<template>
+  <g :transform="transform">
+    <polygon key="1" ref="shape1" :points="keyFrame1[0]" />
+    <polygon key="2" ref="shape2" :points="keyFrame2[0]" />
+    <polygon key="3" ref="shape3" :points="keyFrame3[0]" />
+    <polygon key="4" ref="shape4" :points="keyFrame4[0]" />
+  </g>
+</template>
 
 <style lang="scss" scoped>
 polygon {

--- a/src/components/HeadHorizontal.vue
+++ b/src/components/HeadHorizontal.vue
@@ -1,12 +1,3 @@
-<template>
-  <g :transform="transform">
-    <!-- eslint-disable vue/max-attributes-per-line -->
-    <rect key="1" ref="shape1" x="-60" y="-60" width="120" height="0" />
-    <rect key="2" ref="shape2" x="-60" y="60" width="120" height="0" />
-    <!-- eslint-enable vue/max-attributes-per-line -->
-  </g>
-</template>
-
 <script setup lang="ts">
 import { gsap, Power2 } from 'gsap'
 import { partsCreateTime, partsLeaveTime, type Parts } from '~/lib/head-visual'
@@ -72,6 +63,15 @@ onBeforeUnmount(() => {
   }
 })
 </script>
+
+<template>
+  <g :transform="transform">
+    <!-- eslint-disable vue/max-attributes-per-line -->
+    <rect key="1" ref="shape1" x="-60" y="-60" width="120" height="0" />
+    <rect key="2" ref="shape2" x="-60" y="60" width="120" height="0" />
+    <!-- eslint-enable vue/max-attributes-per-line -->
+  </g>
+</template>
 
 <style lang="scss" scoped>
 rect {

--- a/src/components/HeadPhoto.vue
+++ b/src/components/HeadPhoto.vue
@@ -1,3 +1,59 @@
+<script setup lang="ts">
+import { gsap, Power2 } from 'gsap'
+import { partsCreateTime, partsLeaveTime, type Parts } from '~/lib/head-visual'
+import image01 from '~/assets/images/header/image01.png?url'
+import image02 from '~/assets/images/header/image02.png?url'
+import image03 from '~/assets/images/header/image03.png?url'
+import image04 from '~/assets/images/header/image04.png?url'
+import image05 from '~/assets/images/header/image05.png?url'
+import image06 from '~/assets/images/header/image06.png?url'
+
+const props = defineProps<{
+  item: Parts
+}>()
+
+const shape = ref<SVGCircleElement | null>(null)
+const keyFrame = [0, 60 * (2 ^ 0.5)]
+const images = [image01, image02, image03, image04, image05, image06]
+
+const transform = computed(
+  () =>
+    `translate(${props.item.x}, ${props.item.y}) rotate(${props.item.rotate})`,
+)
+const clipId = computed(() => `photo-clip${props.item.key}`)
+const clipPath = computed(() => `url(#${clipId.value})`)
+
+onMounted(() => {
+  window.setTimeout(() => {
+    if (!shape.value) {
+      return
+    }
+
+    gsap.to(shape.value, {
+      duration: partsCreateTime,
+      attr: {
+        r: keyFrame[1],
+      },
+      ease: Power2.easeOut,
+    })
+  }, 0)
+})
+
+onBeforeUnmount(() => {
+  if (!shape.value) {
+    return
+  }
+
+  gsap.to(shape.value, {
+    duration: partsLeaveTime,
+    attr: {
+      r: keyFrame[0],
+    },
+    ease: Power2.easeOut,
+  })
+})
+</script>
+
 <template>
   <g :transform="transform">
     <clipPath id="clip-boundary">
@@ -68,62 +124,6 @@
     />
   </g>
 </template>
-
-<script setup lang="ts">
-import { gsap, Power2 } from 'gsap'
-import { partsCreateTime, partsLeaveTime, type Parts } from '~/lib/head-visual'
-import image01 from '~/assets/images/header/image01.png?url'
-import image02 from '~/assets/images/header/image02.png?url'
-import image03 from '~/assets/images/header/image03.png?url'
-import image04 from '~/assets/images/header/image04.png?url'
-import image05 from '~/assets/images/header/image05.png?url'
-import image06 from '~/assets/images/header/image06.png?url'
-
-const props = defineProps<{
-  item: Parts
-}>()
-
-const shape = ref<SVGCircleElement | null>(null)
-const keyFrame = [0, 60 * (2 ^ 0.5)]
-const images = [image01, image02, image03, image04, image05, image06]
-
-const transform = computed(
-  () =>
-    `translate(${props.item.x}, ${props.item.y}) rotate(${props.item.rotate})`,
-)
-const clipId = computed(() => `photo-clip${props.item.key}`)
-const clipPath = computed(() => `url(#${clipId.value})`)
-
-onMounted(() => {
-  window.setTimeout(() => {
-    if (!shape.value) {
-      return
-    }
-
-    gsap.to(shape.value, {
-      duration: partsCreateTime,
-      attr: {
-        r: keyFrame[1],
-      },
-      ease: Power2.easeOut,
-    })
-  }, 0)
-})
-
-onBeforeUnmount(() => {
-  if (!shape.value) {
-    return
-  }
-
-  gsap.to(shape.value, {
-    duration: partsLeaveTime,
-    attr: {
-      r: keyFrame[0],
-    },
-    ease: Power2.easeOut,
-  })
-})
-</script>
 
 <style lang="scss" scoped>
 rect {

--- a/src/components/HeadSlash.vue
+++ b/src/components/HeadSlash.vue
@@ -1,10 +1,3 @@
-<template>
-  <g :transform="transform">
-    <polygon key="0" ref="shape1" :points="keyFrame1[0]" />
-    <polygon key="1" ref="shape2" :points="keyFrame2[0]" />
-  </g>
-</template>
-
 <script setup lang="ts">
 import { gsap, Power2 } from 'gsap'
 import { partsCreateTime, partsLeaveTime, type Parts } from '~/lib/head-visual'
@@ -59,6 +52,13 @@ onBeforeUnmount(() => {
   }
 })
 </script>
+
+<template>
+  <g :transform="transform">
+    <polygon key="0" ref="shape1" :points="keyFrame1[0]" />
+    <polygon key="1" ref="shape2" :points="keyFrame2[0]" />
+  </g>
+</template>
 
 <style lang="scss" scoped>
 polygon {

--- a/src/components/HeadSquare.vue
+++ b/src/components/HeadSquare.vue
@@ -1,9 +1,3 @@
-<template>
-  <g :transform="transform">
-    <rect ref="shape" x="0" y="0" width="0" height="0" />
-  </g>
-</template>
-
 <script setup lang="ts">
 import { gsap, Power2 } from 'gsap'
 import { partsCreateTime, partsLeaveTime, type Parts } from '~/lib/head-visual'
@@ -54,6 +48,12 @@ onBeforeUnmount(() => {
   })
 })
 </script>
+
+<template>
+  <g :transform="transform">
+    <rect ref="shape" x="0" y="0" width="0" height="0" />
+  </g>
+</template>
 
 <style lang="scss" scoped>
 rect {

--- a/src/components/HeadTriangle.vue
+++ b/src/components/HeadTriangle.vue
@@ -1,9 +1,3 @@
-<template>
-  <g :transform="transform">
-    <polygon ref="shape" :points="keyFrame[0]" />
-  </g>
-</template>
-
 <script setup lang="ts">
 import { gsap, Power2 } from 'gsap'
 import { partsCreateTime, partsLeaveTime, type Parts } from '~/lib/head-visual'
@@ -49,6 +43,12 @@ onBeforeUnmount(() => {
   })
 })
 </script>
+
+<template>
+  <g :transform="transform">
+    <polygon ref="shape" :points="keyFrame[0]" />
+  </g>
+</template>
 
 <style lang="scss" scoped>
 polygon {

--- a/src/components/TheAccessSection.vue
+++ b/src/components/TheAccessSection.vue
@@ -1,3 +1,11 @@
+<script setup lang="ts">
+import accessImage from '~/assets/images/access.jpg?url'
+import accessImage2x from '~/assets/images/access@2x.jpg?url'
+
+const image2x = accessImage2x
+const imageSrcSet = `${accessImage}, ${accessImage2x} 2x`
+</script>
+
 <template>
   <BaseSection id="the-access-section" class="the-access-section">
     <template v-slot:heading> ACCESS </template>
@@ -53,14 +61,6 @@
     </BaseButton>
   </BaseSection>
 </template>
-
-<script setup lang="ts">
-import accessImage from '~/assets/images/access.jpg?url'
-import accessImage2x from '~/assets/images/access@2x.jpg?url'
-
-const image2x = accessImage2x
-const imageSrcSet = `${accessImage}, ${accessImage2x} 2x`
-</script>
 
 <style lang="scss" scoped>
 .access-container {

--- a/src/components/TheAccessSection.vue
+++ b/src/components/TheAccessSection.vue
@@ -12,8 +12,8 @@ const imageSrcSet = `${accessImage}, ${accessImage2x} 2x`
 
     <div class="access-container">
       <div class="image-container">
-        <div v-lazy-container="{ selector: 'img' }" class="image">
-          <img :data-srcset="imageSrcSet" :data-src="image2x" alt="" />
+        <div class="image">
+          <img :srcset="imageSrcSet" :src="image2x" loading="lazy" alt="" />
         </div>
       </div>
 

--- a/src/components/TheContactForm.vue
+++ b/src/components/TheContactForm.vue
@@ -1,121 +1,3 @@
-<template>
-  <BaseMain class="the-contact-form">
-    <template v-slot:heading> お問い合わせ </template>
-
-    <BaseMainDescription>
-      <!-- prettier-ignore -->
-      <p>
-        Vue.js 日本ユーザーグループへのご質問及びお問い合わせは、以下のお問い合わせフォームよりお願いします。通常、担当者から 3営業日以内でお答えさせていただきます。
-      </p>
-    </BaseMainDescription>
-
-    <form
-      name="contact"
-      data-netlify="true"
-      netlify-honeypot="bot-field"
-      netlify
-      @submit.prevent="handleSubmit"
-    >
-      <!-- Anti-spam Measures -->
-      <div class="hidden">
-        <p>
-          <label>
-            Don’t fill this out:
-            <input name="bot-field" />
-          </label>
-        </p>
-
-        <input type="hidden" name="form-name" value="contact" />
-      </div>
-
-      <!-- Name -->
-      <div class="form-content">
-        <label for="name">お名前<span class="required">（必須）</span></label>
-        <input
-          id="name"
-          v-model.trim="formData.name"
-          :class="{ error: errors.has('name') }"
-          @blur="validateField('name')"
-          name="name"
-          placeholder="お名前"
-          type="text"
-        />
-
-        <div v-show="errors.has('name')" id="name-error" class="has-error">
-          {{ errors.first('name') }}
-        </div>
-      </div>
-
-      <!-- Email -->
-      <div class="form-content">
-        <label for="email">
-          メールアドレス<span class="required">（必須）</span>
-        </label>
-
-        <input
-          id="email"
-          v-model.trim="formData.email"
-          :class="{ error: errors.has('email') }"
-          @blur="validateField('email')"
-          name="email"
-          placeholder="メールアドレス"
-          type="text"
-        />
-
-        <div v-show="errors.has('email')" id="email-error" class="has-error">
-          {{ errors.first('email') }}
-        </div>
-      </div>
-
-      <!-- Organization -->
-      <div class="form-content">
-        <label for="organization"> 会社・団体名等 </label>
-
-        <input
-          id="organization"
-          v-model="formData.organization"
-          name="organization"
-          placeholder="会社・団体名等"
-          type="text"
-        />
-      </div>
-
-      <!-- Message -->
-      <div class="form-content">
-        <label for="message">
-          内容<span class="required">（必須）</span>
-        </label>
-
-        <textarea
-          id="message"
-          v-model="formData.message"
-          :class="{ error: errors.has('message') }"
-          @blur="validateField('message')"
-          name="message"
-          placeholder="例：お問い合わせ内容をご記入ください"
-        />
-
-        <div
-          v-show="errors.has('message')"
-          id="message-error"
-          class="has-error"
-        >
-          {{ errors.first('message') }}
-        </div>
-      </div>
-
-      <BaseButton
-        :disabled="status.hasSent || status.inProgress"
-        :class="{ 'has-sent': status.hasSent }"
-        class="submit-button"
-        type="submit"
-      >
-        {{ buttonValue }}
-      </BaseButton>
-    </form>
-  </BaseMain>
-</template>
-
 <script setup lang="ts">
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -260,6 +142,124 @@ async function handleSubmit() {
   }
 }
 </script>
+
+<template>
+  <BaseMain class="the-contact-form">
+    <template v-slot:heading> お問い合わせ </template>
+
+    <BaseMainDescription>
+      <!-- prettier-ignore -->
+      <p>
+        Vue.js 日本ユーザーグループへのご質問及びお問い合わせは、以下のお問い合わせフォームよりお願いします。通常、担当者から 3営業日以内でお答えさせていただきます。
+      </p>
+    </BaseMainDescription>
+
+    <form
+      name="contact"
+      data-netlify="true"
+      netlify-honeypot="bot-field"
+      netlify
+      @submit.prevent="handleSubmit"
+    >
+      <!-- Anti-spam Measures -->
+      <div class="hidden">
+        <p>
+          <label>
+            Don’t fill this out:
+            <input name="bot-field" />
+          </label>
+        </p>
+
+        <input type="hidden" name="form-name" value="contact" />
+      </div>
+
+      <!-- Name -->
+      <div class="form-content">
+        <label for="name">お名前<span class="required">（必須）</span></label>
+        <input
+          id="name"
+          v-model.trim="formData.name"
+          :class="{ error: errors.has('name') }"
+          @blur="validateField('name')"
+          name="name"
+          placeholder="お名前"
+          type="text"
+        />
+
+        <div v-show="errors.has('name')" id="name-error" class="has-error">
+          {{ errors.first('name') }}
+        </div>
+      </div>
+
+      <!-- Email -->
+      <div class="form-content">
+        <label for="email">
+          メールアドレス<span class="required">（必須）</span>
+        </label>
+
+        <input
+          id="email"
+          v-model.trim="formData.email"
+          :class="{ error: errors.has('email') }"
+          @blur="validateField('email')"
+          name="email"
+          placeholder="メールアドレス"
+          type="text"
+        />
+
+        <div v-show="errors.has('email')" id="email-error" class="has-error">
+          {{ errors.first('email') }}
+        </div>
+      </div>
+
+      <!-- Organization -->
+      <div class="form-content">
+        <label for="organization"> 会社・団体名等 </label>
+
+        <input
+          id="organization"
+          v-model="formData.organization"
+          name="organization"
+          placeholder="会社・団体名等"
+          type="text"
+        />
+      </div>
+
+      <!-- Message -->
+      <div class="form-content">
+        <label for="message">
+          内容<span class="required">（必須）</span>
+        </label>
+
+        <textarea
+          id="message"
+          v-model="formData.message"
+          :class="{ error: errors.has('message') }"
+          @blur="validateField('message')"
+          name="message"
+          placeholder="例：お問い合わせ内容をご記入ください"
+        />
+
+        <div
+          v-show="errors.has('message')"
+          id="message-error"
+          class="has-error"
+        >
+          {{ errors.first('message') }}
+        </div>
+      </div>
+
+      <BaseButton
+        :disabled="status.hasSent || status.inProgress"
+        :class="{ 'has-sent': status.hasSent }"
+        class="submit-button"
+        type="submit"
+      >
+        {{ buttonValue }}
+      </BaseButton>
+    </form>
+  </BaseMain>
+</template>
 
 <style lang="scss" scoped>
 $form-border-color: #eee;

--- a/src/components/TheEventSection.vue
+++ b/src/components/TheEventSection.vue
@@ -1,3 +1,152 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { getAssetImage } from '~/lib/assets'
+
+interface Event {
+  title: string
+  description: string
+  image: string
+
+  // シャギーが目立ったため、オリジナルサイズの画像を利用。そのため image2x を用意していない
+  // https://github.com/kazupon/vuefes-2019/pull/171#issuecomment-530706539
+}
+
+interface Product {
+  name: string
+  price: number
+  description: string
+  image: string
+  image2x: string
+}
+
+const eventImage = (name: string) => getAssetImage(`event/${name}`)
+
+export default defineComponent({
+  data() {
+    return {
+      events: [
+        {
+          title: 'リフレッシュメントスペース',
+          description:
+            '喉が渇いたらお茶やコーヒーはいかがですか？小腹を満たすお菓子もご用意しています。もちろん無料です。休憩できる椅子は譲り合ってご利用ください。',
+          image: eventImage('refreshment.jpg'),
+        },
+        {
+          title: 'スポンサーブースシールラリー',
+          description:
+            '工夫を凝らした展示が楽しめるスポンサーブースが今年も登場。ブースで配られるシールを集めると、特製小物ケース（写真右下）をプレゼントします。数量限定のためお早めに！',
+          image: eventImage('sponsor-booths.jpg'),
+        },
+        {
+          title: '技術同人誌販売スペース',
+          description:
+            'Vue.js や JavaScript に関する技術同人誌を立ち読みし、気に入った本があれば実際に購入できます。あなたの知らない良書が見つかるチャンスかもしれません。',
+          image: eventImage('presents.jpg'),
+        },
+        {
+          title: 'タトゥースペース',
+          description:
+            '顔や手に Vue Fes Japan 特製タトゥーシールを貼り付けて、フェス気分を盛り上げましょう。Vue.js や Nuxt.js のロゴマークをその場ですぐに付けられます。',
+          image: eventImage('tattoo.jpg'),
+        },
+      ] as Event[],
+      caseImage: eventImage('case.jpg'),
+      caseImage2x: eventImage('case@2x.jpg'),
+      products: [
+        {
+          name: 'Tシャツ',
+          price: 2000,
+          description:
+            'Vue Fes Japan 2019 のメインビジュアルをあしらった Tシャツです。洗濯で伸び縮みしにくい生地を使用しています。<br />' +
+            '<br/>' +
+            'カラー：ネイビー<br />' +
+            'サイズ：S / M / L / XL',
+          image: eventImage('t-shirt.png'),
+          image2x: eventImage('t-shirt@2x.png'),
+        },
+        {
+          name: 'パーカー',
+          price: 4500,
+          description:
+            'ポケット付きのフルジップパーカー。肌触りが良いパイル裏地のスウェット生地を使用しています。<br />' +
+            '<br />' +
+            'カラー：ミックスグレー<br />' +
+            'サイズ：S / M / L / XL',
+          image: eventImage('parka.png'),
+          image2x: eventImage('parka@2x.png'),
+        },
+        {
+          name: 'ステンレスマグカップ',
+          price: 1800,
+          description:
+            'レーザー彫刻を施したステンレスマグカップ。オフィスやアウトドアでも活躍が期待できます。<br />' +
+            '<br />' +
+            'カラー：シルバー<br />' +
+            '容量：300ml',
+          image: eventImage('mug.png'),
+          image2x: eventImage('mug@2x.png'),
+        },
+        {
+          name: 'ステンレスタンブラー',
+          price: 2000,
+          description:
+            'レーザー彫刻を施したステンレスタンブラー。真空二重構造で氷を入れてもほとんど結露しません。<br />' +
+            '<br />' +
+            'カラー：シルバー<br />' +
+            '容量：450ml',
+          image: eventImage('tumbler.png'),
+          image2x: eventImage('tumbler@2x.png'),
+        },
+        {
+          name: 'Vue.js クッション',
+          price: 2500,
+          description:
+            '珍しい三角形のクッションです。もちもちとした触感がクセになります。<br />' +
+            '<br />' +
+            'サイズ：30cm以下（予定）',
+          image: eventImage('cushion.png'),
+          image2x: eventImage('cushion@2x.png'),
+        },
+        {
+          name: '缶バッジ 4個セット',
+          price: 500,
+          description:
+            '人気のロゴが入った缶バッジセットです。Vue.js のみ円形と三角形の 2種類が付属します。<br />' +
+            '<br />' +
+            'サイズ：44mm（円形）、70mm（三角形）',
+          image: eventImage('badges.png'),
+          image2x: eventImage('badges@2x.png'),
+        },
+        {
+          name: 'マルチクリーナー',
+          price: 300,
+          description:
+            'メガネ、スマートフォンなどマルチな用途で使えるクリーナーです。印刷面、裏面のどちらでも拭けます。<br />' +
+            '<br />' +
+            'サイズ：15 x 15cm',
+          image: eventImage('cleaner.png'),
+          image2x: eventImage('cleaner@2x.png'),
+        },
+        {
+          name: 'ステッカー',
+          price: 200,
+          description:
+            'テックカンファレンスの定番、ステッカーです。キートップに貼れるサイズのキーボードステッカーも付属。',
+          image: eventImage('stickers.png'),
+          image2x: eventImage('stickers@2x.png'),
+        },
+      ] as Product[],
+      mobileApp: eventImage('mobile-app.png'),
+      mobileApp2x: eventImage('mobile-app@2x.png'),
+      informationTable: eventImage('information-table.jpg'),
+      informationTable2x: eventImage('information-table@2x.jpg'),
+      party: eventImage('party.jpg'),
+      party2x: eventImage('party@2x.jpg'),
+    }
+  },
+})
+</script>
+
 <template>
   <BaseSection id="the-event-section" class="the-event-section">
     <template v-slot:heading> EVENTS </template>
@@ -157,155 +306,6 @@
     </div>
   </BaseSection>
 </template>
-
-<script lang="ts">
-import { defineComponent } from 'vue'
-import { getAssetImage } from '~/lib/assets'
-
-interface Event {
-  title: string
-  description: string
-  image: string
-
-  // シャギーが目立ったため、オリジナルサイズの画像を利用。そのため image2x を用意していない
-  // https://github.com/kazupon/vuefes-2019/pull/171#issuecomment-530706539
-}
-
-interface Product {
-  name: string
-  price: number
-  description: string
-  image: string
-  image2x: string
-}
-
-const eventImage = (name: string) => getAssetImage(`event/${name}`)
-
-export default defineComponent({
-  data() {
-    return {
-      events: [
-        {
-          title: 'リフレッシュメントスペース',
-          description:
-            '喉が渇いたらお茶やコーヒーはいかがですか？小腹を満たすお菓子もご用意しています。もちろん無料です。休憩できる椅子は譲り合ってご利用ください。',
-          image: eventImage('refreshment.jpg'),
-        },
-        {
-          title: 'スポンサーブースシールラリー',
-          description:
-            '工夫を凝らした展示が楽しめるスポンサーブースが今年も登場。ブースで配られるシールを集めると、特製小物ケース（写真右下）をプレゼントします。数量限定のためお早めに！',
-          image: eventImage('sponsor-booths.jpg'),
-        },
-        {
-          title: '技術同人誌販売スペース',
-          description:
-            'Vue.js や JavaScript に関する技術同人誌を立ち読みし、気に入った本があれば実際に購入できます。あなたの知らない良書が見つかるチャンスかもしれません。',
-          image: eventImage('presents.jpg'),
-        },
-        {
-          title: 'タトゥースペース',
-          description:
-            '顔や手に Vue Fes Japan 特製タトゥーシールを貼り付けて、フェス気分を盛り上げましょう。Vue.js や Nuxt.js のロゴマークをその場ですぐに付けられます。',
-          image: eventImage('tattoo.jpg'),
-        },
-      ] as Event[],
-      caseImage: eventImage('case.jpg'),
-      caseImage2x: eventImage('case@2x.jpg'),
-      products: [
-        {
-          name: 'Tシャツ',
-          price: 2000,
-          description:
-            'Vue Fes Japan 2019 のメインビジュアルをあしらった Tシャツです。洗濯で伸び縮みしにくい生地を使用しています。<br />' +
-            '<br/>' +
-            'カラー：ネイビー<br />' +
-            'サイズ：S / M / L / XL',
-          image: eventImage('t-shirt.png'),
-          image2x: eventImage('t-shirt@2x.png'),
-        },
-        {
-          name: 'パーカー',
-          price: 4500,
-          description:
-            'ポケット付きのフルジップパーカー。肌触りが良いパイル裏地のスウェット生地を使用しています。<br />' +
-            '<br />' +
-            'カラー：ミックスグレー<br />' +
-            'サイズ：S / M / L / XL',
-          image: eventImage('parka.png'),
-          image2x: eventImage('parka@2x.png'),
-        },
-        {
-          name: 'ステンレスマグカップ',
-          price: 1800,
-          description:
-            'レーザー彫刻を施したステンレスマグカップ。オフィスやアウトドアでも活躍が期待できます。<br />' +
-            '<br />' +
-            'カラー：シルバー<br />' +
-            '容量：300ml',
-          image: eventImage('mug.png'),
-          image2x: eventImage('mug@2x.png'),
-        },
-        {
-          name: 'ステンレスタンブラー',
-          price: 2000,
-          description:
-            'レーザー彫刻を施したステンレスタンブラー。真空二重構造で氷を入れてもほとんど結露しません。<br />' +
-            '<br />' +
-            'カラー：シルバー<br />' +
-            '容量：450ml',
-          image: eventImage('tumbler.png'),
-          image2x: eventImage('tumbler@2x.png'),
-        },
-        {
-          name: 'Vue.js クッション',
-          price: 2500,
-          description:
-            '珍しい三角形のクッションです。もちもちとした触感がクセになります。<br />' +
-            '<br />' +
-            'サイズ：30cm以下（予定）',
-          image: eventImage('cushion.png'),
-          image2x: eventImage('cushion@2x.png'),
-        },
-        {
-          name: '缶バッジ 4個セット',
-          price: 500,
-          description:
-            '人気のロゴが入った缶バッジセットです。Vue.js のみ円形と三角形の 2種類が付属します。<br />' +
-            '<br />' +
-            'サイズ：44mm（円形）、70mm（三角形）',
-          image: eventImage('badges.png'),
-          image2x: eventImage('badges@2x.png'),
-        },
-        {
-          name: 'マルチクリーナー',
-          price: 300,
-          description:
-            'メガネ、スマートフォンなどマルチな用途で使えるクリーナーです。印刷面、裏面のどちらでも拭けます。<br />' +
-            '<br />' +
-            'サイズ：15 x 15cm',
-          image: eventImage('cleaner.png'),
-          image2x: eventImage('cleaner@2x.png'),
-        },
-        {
-          name: 'ステッカー',
-          price: 200,
-          description:
-            'テックカンファレンスの定番、ステッカーです。キートップに貼れるサイズのキーボードステッカーも付属。',
-          image: eventImage('stickers.png'),
-          image2x: eventImage('stickers@2x.png'),
-        },
-      ] as Product[],
-      mobileApp: eventImage('mobile-app.png'),
-      mobileApp2x: eventImage('mobile-app@2x.png'),
-      informationTable: eventImage('information-table.jpg'),
-      informationTable2x: eventImage('information-table@2x.jpg'),
-      party: eventImage('party.jpg'),
-      party2x: eventImage('party@2x.jpg'),
-    }
-  },
-})
-</script>
 
 <style lang="scss" scoped>
 .notification-container {

--- a/src/components/TheEventSection.vue
+++ b/src/components/TheEventSection.vue
@@ -163,10 +163,11 @@ export default defineComponent({
     </div>
 
     <div class="mobile-app">
-      <div v-lazy-container="{ selector: 'img' }" class="mobile-app-image">
+      <div class="mobile-app-image">
         <img
-          :data-srcset="`${mobileApp}, ${mobileApp2x} 2x`"
-          :data-src="mobileApp2x"
+          :srcset="`${mobileApp}, ${mobileApp2x} 2x`"
+          :src="mobileApp2x"
+          loading="lazy"
           alt=""
         />
       </div>
@@ -207,16 +208,17 @@ export default defineComponent({
 
     <ul class="event-list">
       <li v-for="(event, index) in events" :key="index" class="event">
-        <div v-lazy-container="{ selector: 'img' }" class="event-image">
-          <img :data-src="event.image" alt="" />
+        <div class="event-image">
+          <img :src="event.image" loading="lazy" alt="" />
 
           <div
             v-if="event.title === 'スポンサーブースシールラリー'"
             class="case-image-container"
           >
             <img
-              :data-srcset="`${caseImage}, ${caseImage2x} 2x`"
-              :data-src="caseImage2x"
+              :srcset="`${caseImage}, ${caseImage2x} 2x`"
+              :src="caseImage2x"
+              loading="lazy"
               alt=""
             />
           </div>
@@ -235,22 +237,21 @@ export default defineComponent({
     </ul>
 
     <div class="event-other-images">
-      <div
-        v-lazy-container="{ selector: 'img' }"
-        class="information-table-image"
-      >
+      <div class="information-table-image">
         <img
-          :data-srcset="`${informationTable}, ${informationTable2x} 2x`"
-          :data-src="informationTable2x"
+          :srcset="`${informationTable}, ${informationTable2x} 2x`"
+          :src="informationTable2x"
+          loading="lazy"
           alt=""
         />
       </div>
 
-      <div v-lazy-container="{ selector: 'img' }" class="party-image">
+      <div class="party-image">
         <img
           class="party"
-          :data-srcset="`${party}, ${party2x} 2x`"
-          :data-src="party2x"
+          :srcset="`${party}, ${party2x} 2x`"
+          :src="party2x"
+          loading="lazy"
           alt=""
         />
       </div>
@@ -268,10 +269,11 @@ export default defineComponent({
 
     <ul class="product-list">
       <li v-for="(product, index) in products" :key="index" class="product">
-        <div v-lazy-container="{ selector: 'img' }" class="product-image">
+        <div class="product-image">
           <img
-            :data-srcset="`${product.image}, ${product.image2x} 2x`"
-            :data-src="product.image2x"
+            :srcset="`${product.image}, ${product.image2x} 2x`"
+            :src="product.image2x"
+            loading="lazy"
             alt=""
           />
         </div>

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -1,3 +1,41 @@
+<script setup lang="ts">
+import {
+  faGithub,
+  faTwitter,
+  faYoutube,
+} from '@fortawesome/free-brands-svg-icons'
+
+function encodedUri(): string {
+  return encodeURIComponent(window.location.href)
+}
+
+function hostAndPath(): string {
+  return window.location.host + window.location.pathname
+}
+
+function openTwitterForm() {
+  window.open(
+    `https://twitter.com/share?url=${encodedUri()}&hashtags=vuefes,vuejs&text=${encodeURIComponent(
+      '日本最大級の Vue.js カンファレンス「Vue Fes Japan 2019」',
+    )}`,
+    'tweet',
+    'width=650, height=470',
+  )
+}
+
+function openFacebookForm() {
+  window.open(
+    `https://www.facebook.com/sharer/sharer.php?u=${encodedUri()}&src=sdkpreparse`,
+    'share',
+    'width=670, height=328',
+  )
+}
+
+function openHatenaBookmarkForm() {
+  window.open(`http://b.hatena.ne.jp/entry/s/${hostAndPath()}`, 'bookmark')
+}
+</script>
+
 <template>
   <footer class="the-footer">
     <div class="footer-container">
@@ -138,44 +176,6 @@
     </div>
   </footer>
 </template>
-
-<script setup lang="ts">
-import {
-  faGithub,
-  faTwitter,
-  faYoutube,
-} from '@fortawesome/free-brands-svg-icons'
-
-function encodedUri(): string {
-  return encodeURIComponent(window.location.href)
-}
-
-function hostAndPath(): string {
-  return window.location.host + window.location.pathname
-}
-
-function openTwitterForm() {
-  window.open(
-    `https://twitter.com/share?url=${encodedUri()}&hashtags=vuefes,vuejs&text=${encodeURIComponent(
-      '日本最大級の Vue.js カンファレンス「Vue Fes Japan 2019」',
-    )}`,
-    'tweet',
-    'width=650, height=470',
-  )
-}
-
-function openFacebookForm() {
-  window.open(
-    `https://www.facebook.com/sharer/sharer.php?u=${encodedUri()}&src=sdkpreparse`,
-    'share',
-    'width=670, height=328',
-  )
-}
-
-function openHatenaBookmarkForm() {
-  window.open(`http://b.hatena.ne.jp/entry/s/${hostAndPath()}`, 'bookmark')
-}
-</script>
 
 <style lang="scss" scoped>
 .the-footer {

--- a/src/components/TheHeadSection.vue
+++ b/src/components/TheHeadSection.vue
@@ -1,130 +1,3 @@
-<template>
-  <BaseSection class="the-head-section">
-    <div class="main-visual-wrapper">
-      <ClientOnly>
-        <svg
-          class="main-visual"
-          :viewBox="viewBox"
-          :width="width"
-          :height="height"
-        >
-          <g transform="translate(-6, -6)">
-            <transition-group
-              tag="g"
-              mode="out-in"
-              @enter="enter"
-              @leave="leave"
-            >
-              <g v-for="item in itemsFlatten" :key="item.key">
-                <component :is="item.component" :item="item" />
-              </g>
-            </transition-group>
-          </g>
-        </svg>
-      </ClientOnly>
-    </div>
-
-    <h1 class="title">Vue Fes Japan 2019</h1>
-
-    <div class="date-place">
-      <time datetime="2019-10-12">2019.10.12</time>
-      <span class="date-place__day">SAT</span>
-      <span class="date-place__place">TOC GOTANDA MESSE</span>
-    </div>
-
-    <div class="notification">
-      <h3>チケット返金について追加のお知らせ</h3>
-
-      <!-- prettier-ignore -->
-      <p>
-        2019/11/13 現在、販売元である Universe 側のトラブルにより、一部の方々に対して返金が完了していないことが判明いたしました。これまでの経緯は <a href="https://note.mu/ryamakuchi/n/ncdd3950d7580" target="_blank" rel="noopener noreferrer">note の記事</a> にまとめています。お待たせして申し訳ございませんが、現在対応中とのことです。返金されるまで今しばらくお待ちくださいますようお願い申し上げます。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        2019年11月16日 Vue.js 日本ユーザーグループ 代表 川口 和也
-      </p>
-    </div>
-
-    <div class="notification">
-      <h3>Vue Fes Japan 2019 チケット返金のお知らせ</h3>
-
-      <!-- prettier-ignore -->
-      <p>
-        2019年10月12日（土）TOC 五反田メッセにて開催を予定しておりました「Vue Fes Japan 2019」は、台風19号の接近に伴い開催中止を決定しました。皆様には多大なご迷惑をおかけしますことを、心より深くお詫び申し上げます。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        チケットをご購入いただいた皆様には、チケット代金を全額返金させていただきます。払い戻し処理は、10月12日（土）中に実施を予定しております。処理が完了後、決済プラットフォームの Universe からチケット購入時に入力したメールアドレスにキャンセルの旨を記したメールが送信されます。実際のご返金タイミングは利用されたクレジットカード会社様により異なります。返金確認は、クレジットカードの明細にてご確認いただけます。返金日については、カード会社様にお問い合わせいただくようお願いいたします。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        返金に際して、チケットご購入者側でのお手続きは不要です。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        なお、個人間でのチケット売買や譲渡に関しては、主催者側は責任を負いかねますのでご注意ください。また、Vue Fes Japan 2019 参加に伴って参加者ご自身が手配された交通機関・宿泊施設などの保証は致しかねますのであらかじめご了承ください。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        2019年10月11日 Vue.js 日本ユーザーグループ 代表 川口 和也
-      </p>
-    </div>
-
-    <div class="notification">
-      <h3>Vue Fes Japan 2019 開催中止のお知らせ</h3>
-
-      <!-- prettier-ignore -->
-      <p>
-        2019年10月12日（土）TOC 五反田メッセにて開催を予定しておりました「Vue Fes Japan 2019」は、台風19号の接近に伴い、参加者、スポンサー、スピーカー、スタッフ、すべての人の安全を最優先に考慮し、また JR 東日本の他、主要交通機関が計画運休を発表したことを受け、開催中止を決定しました。
-      </p>
-
-      <p>
-        開催を楽しみにお待ちいただいた皆様には多大なご迷惑をおかけしますことを、心より深くお詫び申し上げます。また中止の決定が開催前日となってしまったことにより、特に遠方からお越しいただく予定だった皆様には多大なご負担をおかけしましたことを重ねてお詫び申し上げます。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        ここで、今回の中止決定の経緯について改めてご説明させていただきます。主催者である我々 Vue.js 日本ユーザーグループは有志による非営利のコミュニティであり、今回のような大規模カンファレンスを開催するための費用は、スポンサー様による協賛金と、ご参加いただく皆様によるチケット売上のみに依存しております。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        そこで万が一の開催中止に備えて、Vue Fes Japan 2019 では <a href="https://note.mu/448jp/n/n36cbb8d2e91f" target="_blank" rel="noopener noreferrer">先日の発表</a> のとおり興行中止保険に加入しています。具体的には、開催当日に開催地より半径 100km 以内に開催に影響を与える自然現象（今回の場合は台風にあたります）がある場合、または開催地への交通機関が運休などで機能しなくなった場合、この 2つの条件のいずれかを満たした場合に一部費用を補償する契約内容です。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        同契約では、最終的に費用が補償されるかどうかの判断は開催当日になされることになります。つまり、計画運休の発表や台風の予想進路が確定的であっても、仮に当日に運休が取り消しになり交通機関が通常通り運行され、台風が開催に影響を与えないと判断された場合は、補償が行われない可能性があります。我々 Vue.js 日本ユーザーグループには、補償が行われなかった場合に多額の金銭的損失を補填できるだけの余力は残念ながらありません。このリスクを最小限に抑えるためには、開催中止のタイミングを当日早朝、または前日夜にすることが最善と考え先日の発表に至りました。
-      </p>
-
-      <p>
-        しかし連日連夜スタッフ内でも協議を重ねた結果、金銭面などのリスクよりも、最終的にはすべての人の安全が何よりも最優先に確保されるべきと考え、当初の予定よりも早く開催中止を決定することになりました。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        チケット代金の返金方法やスケジュールについては、決定次第、本 Web サイトおよび <a href="https://twitter.com/vuefes" target="_blank" rel="noopener noreferrer">公式 Twitter</a> でお知らせいたします。また、興行中止保険が適用となった場合、保険の規約上、Vue.js 日本ユーザーグループとして Vue Fes Japan 2019 の代替イベントを企画・開催することが禁止されております。こちらも併せてお知らせさせていただきます。
-      </p>
-
-      <p>
-        改めて、開催を楽しみにしてくださった皆様に多大なご迷惑、ご心配をおかけしましたことを心より深くお詫び申し上げます。何卒、ご理解いただけますようよろしくお願い申し上げます。
-      </p>
-
-      <!-- prettier-ignore -->
-      <p>
-        2019年10月11日 Vue.js 日本ユーザーグループ 代表 川口 和也
-      </p>
-    </div>
-
-    <LinkToTwitter />
-  </BaseSection>
-</template>
-
 <script setup lang="ts">
 import type { Component } from 'vue'
 import HeadCircle from '~/components/HeadCircle.vue'
@@ -346,6 +219,133 @@ onBeforeUnmount(() => {
   window.removeEventListener('resize', handleResize)
 })
 </script>
+
+<template>
+  <BaseSection class="the-head-section">
+    <div class="main-visual-wrapper">
+      <ClientOnly>
+        <svg
+          class="main-visual"
+          :viewBox="viewBox"
+          :width="width"
+          :height="height"
+        >
+          <g transform="translate(-6, -6)">
+            <transition-group
+              tag="g"
+              mode="out-in"
+              @enter="enter"
+              @leave="leave"
+            >
+              <g v-for="item in itemsFlatten" :key="item.key">
+                <component :is="item.component" :item="item" />
+              </g>
+            </transition-group>
+          </g>
+        </svg>
+      </ClientOnly>
+    </div>
+
+    <h1 class="title">Vue Fes Japan 2019</h1>
+
+    <div class="date-place">
+      <time datetime="2019-10-12">2019.10.12</time>
+      <span class="date-place__day">SAT</span>
+      <span class="date-place__place">TOC GOTANDA MESSE</span>
+    </div>
+
+    <div class="notification">
+      <h3>チケット返金について追加のお知らせ</h3>
+
+      <!-- prettier-ignore -->
+      <p>
+        2019/11/13 現在、販売元である Universe 側のトラブルにより、一部の方々に対して返金が完了していないことが判明いたしました。これまでの経緯は <a href="https://note.mu/ryamakuchi/n/ncdd3950d7580" target="_blank" rel="noopener noreferrer">note の記事</a> にまとめています。お待たせして申し訳ございませんが、現在対応中とのことです。返金されるまで今しばらくお待ちくださいますようお願い申し上げます。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        2019年11月16日 Vue.js 日本ユーザーグループ 代表 川口 和也
+      </p>
+    </div>
+
+    <div class="notification">
+      <h3>Vue Fes Japan 2019 チケット返金のお知らせ</h3>
+
+      <!-- prettier-ignore -->
+      <p>
+        2019年10月12日（土）TOC 五反田メッセにて開催を予定しておりました「Vue Fes Japan 2019」は、台風19号の接近に伴い開催中止を決定しました。皆様には多大なご迷惑をおかけしますことを、心より深くお詫び申し上げます。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        チケットをご購入いただいた皆様には、チケット代金を全額返金させていただきます。払い戻し処理は、10月12日（土）中に実施を予定しております。処理が完了後、決済プラットフォームの Universe からチケット購入時に入力したメールアドレスにキャンセルの旨を記したメールが送信されます。実際のご返金タイミングは利用されたクレジットカード会社様により異なります。返金確認は、クレジットカードの明細にてご確認いただけます。返金日については、カード会社様にお問い合わせいただくようお願いいたします。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        返金に際して、チケットご購入者側でのお手続きは不要です。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        なお、個人間でのチケット売買や譲渡に関しては、主催者側は責任を負いかねますのでご注意ください。また、Vue Fes Japan 2019 参加に伴って参加者ご自身が手配された交通機関・宿泊施設などの保証は致しかねますのであらかじめご了承ください。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        2019年10月11日 Vue.js 日本ユーザーグループ 代表 川口 和也
+      </p>
+    </div>
+
+    <div class="notification">
+      <h3>Vue Fes Japan 2019 開催中止のお知らせ</h3>
+
+      <!-- prettier-ignore -->
+      <p>
+        2019年10月12日（土）TOC 五反田メッセにて開催を予定しておりました「Vue Fes Japan 2019」は、台風19号の接近に伴い、参加者、スポンサー、スピーカー、スタッフ、すべての人の安全を最優先に考慮し、また JR 東日本の他、主要交通機関が計画運休を発表したことを受け、開催中止を決定しました。
+      </p>
+
+      <p>
+        開催を楽しみにお待ちいただいた皆様には多大なご迷惑をおかけしますことを、心より深くお詫び申し上げます。また中止の決定が開催前日となってしまったことにより、特に遠方からお越しいただく予定だった皆様には多大なご負担をおかけしましたことを重ねてお詫び申し上げます。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        ここで、今回の中止決定の経緯について改めてご説明させていただきます。主催者である我々 Vue.js 日本ユーザーグループは有志による非営利のコミュニティであり、今回のような大規模カンファレンスを開催するための費用は、スポンサー様による協賛金と、ご参加いただく皆様によるチケット売上のみに依存しております。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        そこで万が一の開催中止に備えて、Vue Fes Japan 2019 では <a href="https://note.mu/448jp/n/n36cbb8d2e91f" target="_blank" rel="noopener noreferrer">先日の発表</a> のとおり興行中止保険に加入しています。具体的には、開催当日に開催地より半径 100km 以内に開催に影響を与える自然現象（今回の場合は台風にあたります）がある場合、または開催地への交通機関が運休などで機能しなくなった場合、この 2つの条件のいずれかを満たした場合に一部費用を補償する契約内容です。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        同契約では、最終的に費用が補償されるかどうかの判断は開催当日になされることになります。つまり、計画運休の発表や台風の予想進路が確定的であっても、仮に当日に運休が取り消しになり交通機関が通常通り運行され、台風が開催に影響を与えないと判断された場合は、補償が行われない可能性があります。我々 Vue.js 日本ユーザーグループには、補償が行われなかった場合に多額の金銭的損失を補填できるだけの余力は残念ながらありません。このリスクを最小限に抑えるためには、開催中止のタイミングを当日早朝、または前日夜にすることが最善と考え先日の発表に至りました。
+      </p>
+
+      <p>
+        しかし連日連夜スタッフ内でも協議を重ねた結果、金銭面などのリスクよりも、最終的にはすべての人の安全が何よりも最優先に確保されるべきと考え、当初の予定よりも早く開催中止を決定することになりました。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        チケット代金の返金方法やスケジュールについては、決定次第、本 Web サイトおよび <a href="https://twitter.com/vuefes" target="_blank" rel="noopener noreferrer">公式 Twitter</a> でお知らせいたします。また、興行中止保険が適用となった場合、保険の規約上、Vue.js 日本ユーザーグループとして Vue Fes Japan 2019 の代替イベントを企画・開催することが禁止されております。こちらも併せてお知らせさせていただきます。
+      </p>
+
+      <p>
+        改めて、開催を楽しみにしてくださった皆様に多大なご迷惑、ご心配をおかけしましたことを心より深くお詫び申し上げます。何卒、ご理解いただけますようよろしくお願い申し上げます。
+      </p>
+
+      <!-- prettier-ignore -->
+      <p>
+        2019年10月11日 Vue.js 日本ユーザーグループ 代表 川口 和也
+      </p>
+    </div>
+
+    <LinkToTwitter />
+  </BaseSection>
+</template>
 
 <style lang="scss" scoped>
 $svg-gap: 12px;

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -1,3 +1,64 @@
+<script setup lang="ts">
+const isScrolled = ref(false)
+const isOpen = ref(false)
+const rootElement = ref<HTMLElement>()
+let observer: IntersectionObserver | undefined
+
+function disableScrollHandler(e: TouchEvent) {
+  e.preventDefault()
+}
+
+onMounted(() => {
+  const sentinalElement = document.querySelector('.sentinal')
+
+  if (!sentinalElement) {
+    return
+  }
+
+  observer = new IntersectionObserver((entries) => {
+    const sentinal = entries[0]
+
+    if (!sentinal) {
+      return
+    }
+
+    isScrolled.value = !sentinal.isIntersecting
+  })
+  observer.observe(sentinalElement)
+
+  rootElement.value = document.documentElement
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+  closeMenu()
+})
+
+function openMenu() {
+  isOpen.value = true
+
+  if (!rootElement.value) {
+    return
+  }
+
+  rootElement.value.style.overflow = 'hidden'
+  rootElement.value.addEventListener('touchmove', disableScrollHandler, {
+    passive: false,
+  })
+}
+
+function closeMenu() {
+  isOpen.value = false
+
+  if (!rootElement.value) {
+    return
+  }
+
+  rootElement.value.style.overflow = 'auto'
+  rootElement.value.removeEventListener('touchmove', disableScrollHandler)
+}
+</script>
+
 <template>
   <div class="the-header">
     <div class="sentinal" />
@@ -106,67 +167,6 @@
     </div>
   </div>
 </template>
-
-<script setup lang="ts">
-const isScrolled = ref(false)
-const isOpen = ref(false)
-const rootElement = ref<HTMLElement>()
-let observer: IntersectionObserver | undefined
-
-function disableScrollHandler(e: TouchEvent) {
-  e.preventDefault()
-}
-
-onMounted(() => {
-  const sentinalElement = document.querySelector('.sentinal')
-
-  if (!sentinalElement) {
-    return
-  }
-
-  observer = new IntersectionObserver((entries) => {
-    const sentinal = entries[0]
-
-    if (!sentinal) {
-      return
-    }
-
-    isScrolled.value = !sentinal.isIntersecting
-  })
-  observer.observe(sentinalElement)
-
-  rootElement.value = document.documentElement
-})
-
-onBeforeUnmount(() => {
-  observer?.disconnect()
-  closeMenu()
-})
-
-function openMenu() {
-  isOpen.value = true
-
-  if (!rootElement.value) {
-    return
-  }
-
-  rootElement.value.style.overflow = 'hidden'
-  rootElement.value.addEventListener('touchmove', disableScrollHandler, {
-    passive: false,
-  })
-}
-
-function closeMenu() {
-  isOpen.value = false
-
-  if (!rootElement.value) {
-    return
-  }
-
-  rootElement.value.style.overflow = 'auto'
-  rootElement.value.removeEventListener('touchmove', disableScrollHandler)
-}
-</script>
 
 <style lang="scss" scoped>
 .header-container {

--- a/src/components/TheSpeakerListSection.vue
+++ b/src/components/TheSpeakerListSection.vue
@@ -22,20 +22,16 @@ function speakerAvatarSrcSet(speaker: Speaker): string {
     <template v-slot:heading> SPEAKERS </template>
 
     <div class="speaker-container">
-      <div
-        v-for="speaker in speakers"
-        :key="speaker.sys.id"
-        v-lazy-container="{ selector: 'img.avatar' }"
-        class="speaker"
-      >
+      <div v-for="speaker in speakers" :key="speaker.sys.id" class="speaker">
         <nuxt-link
           class="avatar-link"
           :to="`/sessions/${speaker.fields.github}/`"
         >
           <img
             class="avatar"
-            :data-srcset="speakerAvatarSrcSet(speaker)"
-            :data-src="assetUrl(speaker.fields.avatar2x)"
+            :srcset="speakerAvatarSrcSet(speaker)"
+            :src="assetUrl(speaker.fields.avatar2x)"
+            loading="lazy"
             alt=""
           />
         </nuxt-link>

--- a/src/components/TheSpeakerListSection.vue
+++ b/src/components/TheSpeakerListSection.vue
@@ -1,3 +1,22 @@
+<script setup lang="ts">
+import type { Asset, AssetLink } from '~/types/contentful'
+import type Speaker from '~/types/speaker'
+
+const { speakers } = useSiteData()
+
+function assetUrl(asset: Asset | AssetLink): string {
+  if (!('fields' in asset)) {
+    throw new Error('Speaker asset was not resolved')
+  }
+
+  return asset.fields.file.url
+}
+
+function speakerAvatarSrcSet(speaker: Speaker): string {
+  return `${assetUrl(speaker.fields.avatar)}, ${assetUrl(speaker.fields.avatar2x)} 2x`
+}
+</script>
+
 <template>
   <BaseSection id="the-speaker-list-section" class="the-speaker-list-section">
     <template v-slot:heading> SPEAKERS </template>
@@ -37,25 +56,6 @@
     </div>
   </BaseSection>
 </template>
-
-<script setup lang="ts">
-import type { Asset, AssetLink } from '~/types/contentful'
-import type Speaker from '~/types/speaker'
-
-const { speakers } = useSiteData()
-
-function assetUrl(asset: Asset | AssetLink): string {
-  if (!('fields' in asset)) {
-    throw new Error('Speaker asset was not resolved')
-  }
-
-  return asset.fields.file.url
-}
-
-function speakerAvatarSrcSet(speaker: Speaker): string {
-  return `${assetUrl(speaker.fields.avatar)}, ${assetUrl(speaker.fields.avatar2x)} 2x`
-}
-</script>
 
 <style lang="scss" scoped>
 .speaker-container {

--- a/src/components/TheSponsorListSection.vue
+++ b/src/components/TheSponsorListSection.vue
@@ -22,10 +22,11 @@ const { sponsorPlansHavingSponsors, sponsorsByPlan } = useSiteData()
             class="sponsor"
           >
             <nuxt-link :to="`/sponsors/#sponsor_${sponsor.sys.id}`">
-              <div v-lazy-container="{ selector: 'img' }">
+              <div>
                 <img
                   class="sponsor-image"
-                  :data-src="sponsor.fields.banner.fields.file.url"
+                  :src="sponsor.fields.banner.fields.file.url"
+                  loading="lazy"
                   :alt="sponsor.fields.name"
                 />
               </div>

--- a/src/components/TheSponsorListSection.vue
+++ b/src/components/TheSponsorListSection.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+const { sponsorPlansHavingSponsors, sponsorsByPlan } = useSiteData()
+</script>
+
 <template>
   <BaseSection id="the-sponsor-list-section" class="the-sponsor-list-section">
     <template v-slot:heading> SPONSORS </template>
@@ -32,10 +36,6 @@
     </ul>
   </BaseSection>
 </template>
-
-<script setup lang="ts">
-const { sponsorPlansHavingSponsors, sponsorsByPlan } = useSiteData()
-</script>
 
 <style lang="scss" scoped>
 ul {

--- a/src/components/TheStaffListSection.vue
+++ b/src/components/TheStaffListSection.vue
@@ -1,53 +1,3 @@
-<template>
-  <BaseSection id="the-staff-list-section" class="the-staff-list-section">
-    <template v-slot:heading> TEAM </template>
-
-    <!-- prettier-ignore -->
-    <template v-slot:heading-copy>
-      Vue Fes Japan 2019 は、Vue.js 日本ユーザーグループのスタッフによって企画・運営されています。
-    </template>
-
-    <div class="staff-list-container">
-      <h3 class="sub-heading">CORE STAFF</h3>
-
-      <ul class="staff-list">
-        <li v-for="staff in leaderAndStaffs" :key="staff.name" class="staff">
-          <a :href="staff.link" target="_blank" rel="noopener">
-            <div v-lazy-container="{ selector: 'img' }">
-              <!-- prettier-ignore-attribute -->
-              <img
-                :data-srcset="staffAvatarSrcSet(staff.avatar)"
-                :data-src="staffAvatarSrc(staff.avatar)"
-                alt=""
-              />
-            </div>
-            @{{ staff.name }}
-          </a>
-        </li>
-      </ul>
-
-      <h3 class="sub-heading">VOLUNTEER</h3>
-
-      <ul class="volunteer-list">
-        <li
-          v-for="(volunteer, index) in sortedVolunteers"
-          :key="index"
-          class="volunteer"
-        >
-          <div v-lazy-container="{ selector: 'img' }">
-            <!-- prettier-ignore-attribute -->
-            <img
-              :data-srcset="volunteerAvatarSrcSet(volunteer.avatar)"
-              :data-src="volunteerAvatarSrc(volunteer.avatar)"
-              :alt="volunteer.name"
-            />
-          </div>
-        </li>
-      </ul>
-    </div>
-  </BaseSection>
-</template>
-
 <script lang="ts">
 import { defineComponent } from 'vue'
 import { createSrcSet, getAssetImage } from '~/lib/assets'
@@ -503,6 +453,56 @@ export default defineComponent({
   },
 })
 </script>
+
+<template>
+  <BaseSection id="the-staff-list-section" class="the-staff-list-section">
+    <template v-slot:heading> TEAM </template>
+
+    <!-- prettier-ignore -->
+    <template v-slot:heading-copy>
+      Vue Fes Japan 2019 は、Vue.js 日本ユーザーグループのスタッフによって企画・運営されています。
+    </template>
+
+    <div class="staff-list-container">
+      <h3 class="sub-heading">CORE STAFF</h3>
+
+      <ul class="staff-list">
+        <li v-for="staff in leaderAndStaffs" :key="staff.name" class="staff">
+          <a :href="staff.link" target="_blank" rel="noopener">
+            <div v-lazy-container="{ selector: 'img' }">
+              <!-- prettier-ignore-attribute -->
+              <img
+                :data-srcset="staffAvatarSrcSet(staff.avatar)"
+                :data-src="staffAvatarSrc(staff.avatar)"
+                alt=""
+              />
+            </div>
+            @{{ staff.name }}
+          </a>
+        </li>
+      </ul>
+
+      <h3 class="sub-heading">VOLUNTEER</h3>
+
+      <ul class="volunteer-list">
+        <li
+          v-for="(volunteer, index) in sortedVolunteers"
+          :key="index"
+          class="volunteer"
+        >
+          <div v-lazy-container="{ selector: 'img' }">
+            <!-- prettier-ignore-attribute -->
+            <img
+              :data-srcset="volunteerAvatarSrcSet(volunteer.avatar)"
+              :data-src="volunteerAvatarSrc(volunteer.avatar)"
+              :alt="volunteer.name"
+            />
+          </div>
+        </li>
+      </ul>
+    </div>
+  </BaseSection>
+</template>
 
 <style lang="scss" scoped>
 .staff-list-container {

--- a/src/components/TheStaffListSection.vue
+++ b/src/components/TheStaffListSection.vue
@@ -469,11 +469,12 @@ export default defineComponent({
       <ul class="staff-list">
         <li v-for="staff in leaderAndStaffs" :key="staff.name" class="staff">
           <a :href="staff.link" target="_blank" rel="noopener">
-            <div v-lazy-container="{ selector: 'img' }">
+            <div>
               <!-- prettier-ignore-attribute -->
               <img
-                :data-srcset="staffAvatarSrcSet(staff.avatar)"
-                :data-src="staffAvatarSrc(staff.avatar)"
+                :srcset="staffAvatarSrcSet(staff.avatar)"
+                :src="staffAvatarSrc(staff.avatar)"
+                loading="lazy"
                 alt=""
               />
             </div>
@@ -490,11 +491,12 @@ export default defineComponent({
           :key="index"
           class="volunteer"
         >
-          <div v-lazy-container="{ selector: 'img' }">
+          <div>
             <!-- prettier-ignore-attribute -->
             <img
-              :data-srcset="volunteerAvatarSrcSet(volunteer.avatar)"
-              :data-src="volunteerAvatarSrc(volunteer.avatar)"
+              :srcset="volunteerAvatarSrcSet(volunteer.avatar)"
+              :src="volunteerAvatarSrc(volunteer.avatar)"
+              loading="lazy"
               :alt="volunteer.name"
             />
           </div>

--- a/src/components/TheTicketSection.vue
+++ b/src/components/TheTicketSection.vue
@@ -40,8 +40,13 @@ const imageTwoSrcSet = `${imageTwo}, ${imageTwo2x} 2x`
           <p><span>7,000</span> 円</p>
         </div>
 
-        <div v-lazy-container="{ selector: 'img' }" class="image">
-          <img :data-srcset="imageOneSrcSet" :data-src="imageOne2x" alt="" />
+        <div class="image">
+          <img
+            :srcset="imageOneSrcSet"
+            :src="imageOne2x"
+            loading="lazy"
+            alt=""
+          />
         </div>
       </div>
 
@@ -51,8 +56,13 @@ const imageTwoSrcSet = `${imageTwo}, ${imageTwo2x} 2x`
           <p><span>10,000</span> 円</p>
         </div>
 
-        <div v-lazy-container="{ selector: 'img' }" class="image">
-          <img :data-srcset="imageTwoSrcSet" :data-src="imageTwo2x" alt="" />
+        <div class="image">
+          <img
+            :srcset="imageTwoSrcSet"
+            :src="imageTwo2x"
+            loading="lazy"
+            alt=""
+          />
         </div>
       </div>
     </div>

--- a/src/components/TheTicketSection.vue
+++ b/src/components/TheTicketSection.vue
@@ -1,3 +1,13 @@
+<script setup lang="ts">
+import imageOne from '~/assets/images/ticket/image1.jpg?url'
+import imageOne2x from '~/assets/images/ticket/image1@2x.jpg?url'
+import imageTwo from '~/assets/images/ticket/image2.jpg?url'
+import imageTwo2x from '~/assets/images/ticket/image2@2x.jpg?url'
+
+const imageOneSrcSet = `${imageOne}, ${imageOne2x} 2x`
+const imageTwoSrcSet = `${imageTwo}, ${imageTwo2x} 2x`
+</script>
+
 <template>
   <BaseSection id="the-ticket-section" class="the-ticket-section">
     <template v-slot:heading> TICKET </template>
@@ -126,16 +136,6 @@
     </div>
   </BaseSection>
 </template>
-
-<script setup lang="ts">
-import imageOne from '~/assets/images/ticket/image1.jpg?url'
-import imageOne2x from '~/assets/images/ticket/image1@2x.jpg?url'
-import imageTwo from '~/assets/images/ticket/image2.jpg?url'
-import imageTwo2x from '~/assets/images/ticket/image2@2x.jpg?url'
-
-const imageOneSrcSet = `${imageOne}, ${imageOne2x} 2x`
-const imageTwoSrcSet = `${imageTwo}, ${imageTwo2x} 2x`
-</script>
 
 <style lang="scss" scoped>
 // prettier-ignore

--- a/src/components/TheTimeTableSection.vue
+++ b/src/components/TheTimeTableSection.vue
@@ -1,3 +1,19 @@
+<script setup lang="ts">
+import { formatTime } from '~/lib/time'
+
+const { timeTableSections, findEventContainerById } = useSiteData()
+
+function eventContainerById(id: string) {
+  const eventContainer = findEventContainerById(id)
+
+  if (!eventContainer) {
+    throw new Error(`Unknown event container: ${id}`)
+  }
+
+  return eventContainer
+}
+</script>
+
 <template>
   <BaseSection id="the-time-table-section" class="the-time-table-section">
     <template v-slot:heading> TIME TABLE </template>
@@ -39,22 +55,6 @@
     </div>
   </BaseSection>
 </template>
-
-<script setup lang="ts">
-import { formatTime } from '~/lib/time'
-
-const { timeTableSections, findEventContainerById } = useSiteData()
-
-function eventContainerById(id: string) {
-  const eventContainer = findEventContainerById(id)
-
-  if (!eventContainer) {
-    throw new Error(`Unknown event container: ${id}`)
-  }
-
-  return eventContainer
-}
-</script>
 
 <style lang="scss" scoped>
 .the-time-table-section {

--- a/src/components/TheTimeTableSection/Event.vue
+++ b/src/components/TheTimeTableSection/Event.vue
@@ -1,10 +1,3 @@
-<template>
-  <div class="event">
-    {{ event.fields.title }}
-    <span v-if="isCommunitySession" class="note-mark">※</span>
-  </div>
-</template>
-
 <script setup lang="ts">
 import type EventType from '~/types/event'
 
@@ -16,6 +9,13 @@ const isCommunitySession = computed(
   () => props.event.sys.id === '7HH2CbTRcGkUYp9OF1LIVu',
 )
 </script>
+
+<template>
+  <div class="event">
+    {{ event.fields.title }}
+    <span v-if="isCommunitySession" class="note-mark">※</span>
+  </div>
+</template>
 
 <style lang="scss" scoped>
 .event {

--- a/src/components/TheTimeTableSection/EventContainer.vue
+++ b/src/components/TheTimeTableSection/EventContainer.vue
@@ -1,60 +1,3 @@
-<template>
-  <div
-    class="event-container"
-    :class="{
-      'event-container--has-room': eventContainer.fields.room,
-      'event-container--has-sessions': hasSessions && !hasKeynote,
-      'event-container--has-events': hasEvents,
-      'event-container--has-events-closed': hasEventsClosed,
-    }"
-  >
-    <Room
-      v-if="eventContainer.fields.room"
-      :room="eventContainer.fields.room"
-    />
-
-    <div
-      v-if="hasTranslation"
-      class="translation"
-      :class="{ 'translation--is-keynote': hasKeynote }"
-    >
-      <img src="~/assets/images/icon-translation.svg" alt="" />
-      <span class="translation-text">同時通訳あり</span>
-    </div>
-
-    <div class="content">
-      <div
-        v-if="hasEventContainerParts"
-        class="session__content half-session__container"
-      >
-        <!-- eventContainerPart -->
-        <!-- prettier-ignore -->
-        <div
-          v-for="eventContainerPart in eventContainer.fields.contents"
-          :key="eventContainerPart.sys.id"
-          class="event-container-part"
-        >
-          <div class="event-container-part__time">
-            {{ formatTime(eventContainerPartById(eventContainerPart.sys.id).fields.startAt) }} - {{ formatTime(eventContainerPartById(eventContainerPart.sys.id).fields.endAt) }}
-          </div>
-
-          <div class="event-container-part__content">
-            <EventContent :content="eventContainerPartContent(eventContainerPart.sys.id)" />
-          </div>
-        </div>
-      </div>
-
-      <template v-else>
-        <EventContent
-          v-for="content in eventContainer.fields.contents"
-          :key="content.sys.id"
-          :content="eventContent(content)"
-        />
-      </template>
-    </div>
-  </div>
-</template>
-
 <script setup lang="ts">
 import { formatTime } from '~/lib/time'
 import type { EntryLink } from '~/types/contentful'
@@ -146,6 +89,63 @@ const hasEventsClosed = computed(() =>
   ),
 )
 </script>
+
+<template>
+  <div
+    class="event-container"
+    :class="{
+      'event-container--has-room': eventContainer.fields.room,
+      'event-container--has-sessions': hasSessions && !hasKeynote,
+      'event-container--has-events': hasEvents,
+      'event-container--has-events-closed': hasEventsClosed,
+    }"
+  >
+    <Room
+      v-if="eventContainer.fields.room"
+      :room="eventContainer.fields.room"
+    />
+
+    <div
+      v-if="hasTranslation"
+      class="translation"
+      :class="{ 'translation--is-keynote': hasKeynote }"
+    >
+      <img src="~/assets/images/icon-translation.svg" alt="" />
+      <span class="translation-text">同時通訳あり</span>
+    </div>
+
+    <div class="content">
+      <div
+        v-if="hasEventContainerParts"
+        class="session__content half-session__container"
+      >
+        <!-- eventContainerPart -->
+        <!-- prettier-ignore -->
+        <div
+          v-for="eventContainerPart in eventContainer.fields.contents"
+          :key="eventContainerPart.sys.id"
+          class="event-container-part"
+        >
+          <div class="event-container-part__time">
+            {{ formatTime(eventContainerPartById(eventContainerPart.sys.id).fields.startAt) }} - {{ formatTime(eventContainerPartById(eventContainerPart.sys.id).fields.endAt) }}
+          </div>
+
+          <div class="event-container-part__content">
+            <EventContent :content="eventContainerPartContent(eventContainerPart.sys.id)" />
+          </div>
+        </div>
+      </div>
+
+      <template v-else>
+        <EventContent
+          v-for="content in eventContainer.fields.contents"
+          :key="content.sys.id"
+          :content="eventContent(content)"
+        />
+      </template>
+    </div>
+  </div>
+</template>
 
 <style lang="scss" scoped>
 $event-container-min-height--is-small: 10.4vw;

--- a/src/components/TheTimeTableSection/EventContent.vue
+++ b/src/components/TheTimeTableSection/EventContent.vue
@@ -1,3 +1,20 @@
+<script setup lang="ts">
+import type EventType from '~/types/event'
+import type SessionType from '~/types/session'
+
+defineProps<{
+  content: SessionType | EventType
+}>()
+
+function asSession(content: SessionType | EventType): SessionType {
+  return content as SessionType
+}
+
+function asEvent(content: SessionType | EventType): EventType {
+  return content as EventType
+}
+</script>
+
 <template>
   <div class="event-content">
     <template v-if="content.sys.contentType.sys.id === 'session'">
@@ -15,20 +32,3 @@
     </template>
   </div>
 </template>
-
-<script setup lang="ts">
-import type EventType from '~/types/event'
-import type SessionType from '~/types/session'
-
-defineProps<{
-  content: SessionType | EventType
-}>()
-
-function asSession(content: SessionType | EventType): SessionType {
-  return content as SessionType
-}
-
-function asEvent(content: SessionType | EventType): EventType {
-  return content as EventType
-}
-</script>

--- a/src/components/TheTimeTableSection/Keynote.vue
+++ b/src/components/TheTimeTableSection/Keynote.vue
@@ -1,3 +1,10 @@
+<script setup lang="ts">
+import keynoteAvatar from '~/assets/images/speakers/yyx990803.jpg?url'
+import keynoteAvatar2x from '~/assets/images/speakers/yyx990803@2x.jpg?url'
+
+const keynoteAvatarSrcSet = `${keynoteAvatar}, ${keynoteAvatar2x} 2x`
+</script>
+
 <template>
   <div v-lazy-container="{ selector: 'img' }" class="keynote">
     <nuxt-link class="link-to-session" to="/sessions/yyx990803/">
@@ -18,13 +25,6 @@
     </div>
   </div>
 </template>
-
-<script setup lang="ts">
-import keynoteAvatar from '~/assets/images/speakers/yyx990803.jpg?url'
-import keynoteAvatar2x from '~/assets/images/speakers/yyx990803@2x.jpg?url'
-
-const keynoteAvatarSrcSet = `${keynoteAvatar}, ${keynoteAvatar2x} 2x`
-</script>
 
 <style lang="scss" scoped>
 .keynote {

--- a/src/components/TheTimeTableSection/Keynote.vue
+++ b/src/components/TheTimeTableSection/Keynote.vue
@@ -6,12 +6,13 @@ const keynoteAvatarSrcSet = `${keynoteAvatar}, ${keynoteAvatar2x} 2x`
 </script>
 
 <template>
-  <div v-lazy-container="{ selector: 'img' }" class="keynote">
+  <div class="keynote">
     <nuxt-link class="link-to-session" to="/sessions/yyx990803/">
       <img
         class="avatar"
-        :data-srcset="keynoteAvatarSrcSet"
-        :data-src="keynoteAvatar2x"
+        :srcset="keynoteAvatarSrcSet"
+        :src="keynoteAvatar2x"
+        loading="lazy"
         alt=""
       />
     </nuxt-link>

--- a/src/components/TheTimeTableSection/Room.vue
+++ b/src/components/TheTimeTableSection/Room.vue
@@ -1,9 +1,3 @@
-<template>
-  <div class="room" :class="roomClasses.get(room.sys.id)">
-    {{ room.fields.name }}
-  </div>
-</template>
-
 <script setup lang="ts">
 import type RoomType from '~/types/room'
 
@@ -17,6 +11,12 @@ const roomClasses = new Map([
   ['1rnDVEsknx6MhhPgMAS9Gj', 'room--is-yesod'],
 ])
 </script>
+
+<template>
+  <div class="room" :class="roomClasses.get(room.sys.id)">
+    {{ room.fields.name }}
+  </div>
+</template>
 
 <style lang="scss" scoped>
 .room {

--- a/src/components/TheTimeTableSection/Session.vue
+++ b/src/components/TheTimeTableSection/Session.vue
@@ -1,19 +1,3 @@
-<template>
-  <div class="session">
-    <nuxt-link class="link-to-session" :to="`/sessions/${sessionIdAlias}/`">
-      {{ session.fields.title }}
-    </nuxt-link>
-
-    <div
-      v-for="speaker in session.fields.speakers"
-      :key="speaker.sys.id"
-      class="speaker-name"
-    >
-      {{ speakerById(speaker.sys.id).fields.name }}
-    </div>
-  </div>
-</template>
-
 <script setup lang="ts">
 import type SessionType from '~/types/session'
 
@@ -38,6 +22,22 @@ function speakerById(id: string) {
   return speaker
 }
 </script>
+
+<template>
+  <div class="session">
+    <nuxt-link class="link-to-session" :to="`/sessions/${sessionIdAlias}/`">
+      {{ session.fields.title }}
+    </nuxt-link>
+
+    <div
+      v-for="speaker in session.fields.speakers"
+      :key="speaker.sys.id"
+      class="speaker-name"
+    >
+      {{ speakerById(speaker.sys.id).fields.name }}
+    </div>
+  </div>
+</template>
 
 <style lang="scss" scoped>
 .session {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+await useSiteDataFetch()
+</script>
+
 <template>
   <div>
     <TheHeader />
@@ -5,7 +9,3 @@
     <TheFooter />
   </div>
 </template>
-
-<script setup lang="ts">
-await useSiteDataFetch()
-</script>

--- a/src/pages/code-of-conduct.vue
+++ b/src/pages/code-of-conduct.vue
@@ -1,3 +1,14 @@
+<script setup lang="ts">
+const route = useRoute()
+
+usePageMetadata({
+  path: route.path,
+  title: '行動規範 | Vue Fes Japan 2019',
+  description:
+    'Vue Fes Japan のすべての参加者、スピーカー、スポンサー、スタッフは、オープンかつ友好的な環境を育むため、以下の行動規範に同意していただく必要があります。',
+})
+</script>
+
 <template>
   <!-- prettier-ignore -->
   <BaseMain class="code-of-conduct-page">
@@ -62,14 +73,3 @@
     </BaseButton>
   </BaseMain>
 </template>
-
-<script setup lang="ts">
-const route = useRoute()
-
-usePageMetadata({
-  path: route.path,
-  title: '行動規範 | Vue Fes Japan 2019',
-  description:
-    'Vue Fes Japan のすべての参加者、スピーカー、スポンサー、スタッフは、オープンかつ友好的な環境を育むため、以下の行動規範に同意していただく必要があります。',
-})
-</script>

--- a/src/pages/contact.vue
+++ b/src/pages/contact.vue
@@ -1,9 +1,3 @@
-<template>
-  <div class="contact-page">
-    <TheContactForm />
-  </div>
-</template>
-
 <script setup lang="ts">
 const route = useRoute()
 
@@ -13,3 +7,9 @@ usePageMetadata({
   description: 'Vue Fes Japan 2019 についてのお問い合わせフォームです。',
 })
 </script>
+
+<template>
+  <div class="contact-page">
+    <TheContactForm />
+  </div>
+</template>

--- a/src/pages/privacy.vue
+++ b/src/pages/privacy.vue
@@ -1,3 +1,13 @@
+<script setup lang="ts">
+const route = useRoute()
+
+usePageMetadata({
+  path: route.path,
+  title: 'プライバシーポリシー | Vue Fes Japan 2019',
+  description: 'Vue Fes Japan 2019 のプライバシーポリシー情報です。',
+})
+</script>
+
 <template>
   <BaseMain class="privacy-page">
     <template v-slot:heading> プライバシーポリシー </template>
@@ -254,16 +264,6 @@
     <BaseButton to="/"> トップに戻る </BaseButton>
   </BaseMain>
 </template>
-
-<script setup lang="ts">
-const route = useRoute()
-
-usePageMetadata({
-  path: route.path,
-  title: 'プライバシーポリシー | Vue Fes Japan 2019',
-  description: 'Vue Fes Japan 2019 のプライバシーポリシー情報です。',
-})
-</script>
 
 <style lang="scss" scoped>
 li {

--- a/src/pages/sessions/[speakerId].vue
+++ b/src/pages/sessions/[speakerId].vue
@@ -1,67 +1,3 @@
-<template>
-  <BaseMain class="session-page">
-    <h2 class="heading">SESSION</h2>
-
-    <div class="session">
-      <!-- eslint-disable vue/singleline-html-element-content-newline -->
-      <div class="session-time">{{ session.fields.time }}min</div>
-      <!-- eslint-enable vue/singleline-html-element-content-newline -->
-
-      <h1 class="session-title">
-        {{ session.fields.title }}
-      </h1>
-
-      <!-- eslint-disable vue/no-v-html -->
-      <div class="session-description" v-html="sessionDescriptionHtml" />
-      <!-- eslint-enable vue/no-v-html -->
-    </div>
-
-    <div class="speaker">
-      <img
-        class="speaker-avatar"
-        :srcset="speakerAvatarSrcSet"
-        :src="assetUrl(speaker.fields.avatar2x)"
-        alt=""
-      />
-
-      <p class="speaker-title">
-        {{ speaker.fields.title }}
-      </p>
-
-      <h2 class="speaker-name">
-        {{ speaker.fields.name }}
-      </h2>
-
-      <!-- eslint-disable vue/no-v-html -->
-      <div class="speaker-description" v-html="speakerDescriptionHtml" />
-      <!-- eslint-enable vue/no-v-html -->
-
-      <div class="speaker-social">
-        <a
-          v-if="speaker.fields.twitter"
-          class="twitter"
-          :href="`https://twitter.com/${speaker.fields.twitter}`"
-          target="_blank"
-          rel="noopener"
-        >
-          <img src="~/assets/images/logo-twitter.svg" alt="Twitter" />
-        </a>
-
-        <a
-          class="github"
-          :href="`https://github.com/${speaker.fields.github}`"
-          target="_blank"
-          rel="noopener"
-        >
-          <img src="~/assets/images/icon-github.svg" alt="GitHub" />
-        </a>
-      </div>
-    </div>
-
-    <BaseButton to="/"> トップに戻る </BaseButton>
-  </BaseMain>
-</template>
-
 <script setup lang="ts">
 import { renderMarkdown } from '~/lib/markdown'
 import type { Asset, AssetLink } from '~/types/contentful'
@@ -159,6 +95,70 @@ useHead(() => {
   }
 })
 </script>
+
+<template>
+  <BaseMain class="session-page">
+    <h2 class="heading">SESSION</h2>
+
+    <div class="session">
+      <!-- eslint-disable vue/singleline-html-element-content-newline -->
+      <div class="session-time">{{ session.fields.time }}min</div>
+      <!-- eslint-enable vue/singleline-html-element-content-newline -->
+
+      <h1 class="session-title">
+        {{ session.fields.title }}
+      </h1>
+
+      <!-- eslint-disable vue/no-v-html -->
+      <div class="session-description" v-html="sessionDescriptionHtml" />
+      <!-- eslint-enable vue/no-v-html -->
+    </div>
+
+    <div class="speaker">
+      <img
+        class="speaker-avatar"
+        :srcset="speakerAvatarSrcSet"
+        :src="assetUrl(speaker.fields.avatar2x)"
+        alt=""
+      />
+
+      <p class="speaker-title">
+        {{ speaker.fields.title }}
+      </p>
+
+      <h2 class="speaker-name">
+        {{ speaker.fields.name }}
+      </h2>
+
+      <!-- eslint-disable vue/no-v-html -->
+      <div class="speaker-description" v-html="speakerDescriptionHtml" />
+      <!-- eslint-enable vue/no-v-html -->
+
+      <div class="speaker-social">
+        <a
+          v-if="speaker.fields.twitter"
+          class="twitter"
+          :href="`https://twitter.com/${speaker.fields.twitter}`"
+          target="_blank"
+          rel="noopener"
+        >
+          <img src="~/assets/images/logo-twitter.svg" alt="Twitter" />
+        </a>
+
+        <a
+          class="github"
+          :href="`https://github.com/${speaker.fields.github}`"
+          target="_blank"
+          rel="noopener"
+        >
+          <img src="~/assets/images/icon-github.svg" alt="GitHub" />
+        </a>
+      </div>
+    </div>
+
+    <BaseButton to="/"> トップに戻る </BaseButton>
+  </BaseMain>
+</template>
 
 <style lang="scss" scoped>
 .heading {
@@ -317,42 +317,6 @@ useHead(() => {
       &:hover {
         opacity: 0.4;
       }
-    }
-  }
-}
-</style>
-
-<style lang="scss">
-@use '~/assets/stylesheets/foundation/typography.scss' as *;
-
-.session-page {
-  .session-description {
-    font-size: $font-size-default;
-    line-height: 1.8;
-
-    @media screen and (min-width: $layout-breakpoint--is-small-up) {
-      font-size: $font-size-default--is-small-up;
-    }
-
-    ul {
-      list-style-position: inside;
-
-      li {
-        list-style-type: disc;
-      }
-
-      ul {
-        padding-left: 2em;
-      }
-    }
-  }
-
-  .speaker-description,
-  .speaker-description p {
-    font-size: 3vw;
-
-    @media screen and (min-width: $layout-breakpoint--is-small-up) {
-      font-size: 18px;
     }
   }
 }

--- a/src/pages/sponsors.vue
+++ b/src/pages/sponsors.vue
@@ -1,3 +1,14 @@
+<script setup lang="ts">
+const route = useRoute()
+const { sponsorPlansHavingSponsors, sponsorsByPlan } = useSiteData()
+
+usePageMetadata({
+  path: route.path,
+  title: 'スポンサー一覧 | Vue Fes Japan 2019',
+  description: 'Vue Fes Japan 2019 のスポンサー情報です。',
+})
+</script>
+
 <template>
   <BaseMain class="sponsors-page">
     <template v-slot:heading> SPONSORS </template>
@@ -72,17 +83,6 @@
     <BaseButton to="/"> トップに戻る </BaseButton>
   </BaseMain>
 </template>
-
-<script setup lang="ts">
-const route = useRoute()
-const { sponsorPlansHavingSponsors, sponsorsByPlan } = useSiteData()
-
-usePageMetadata({
-  path: route.path,
-  title: 'スポンサー一覧 | Vue Fes Japan 2019',
-  description: 'Vue Fes Japan 2019 のスポンサー情報です。',
-})
-</script>
 
 <style lang="scss" scoped>
 ul,


### PR DESCRIPTION
                                                                                                      
  🔗 Linked issue                                                                                   
         
  resolves #235

  📚 Description

このPRは、Nuxt 4への移行後に発生していたNetlifyでのデプロイプレビューの問題を修正し、前回の引き続きコードのモダン化を行うものです。

Netlifyでのビルド失敗は、Vue 3ではなくVue 2が環境内で解決されてしまうことが原因でした。これは、netlify.tomlに[build]セクションが不足していたこと、およびVueが明示的な直接依存関係として定義されていなかったために発生していました。

また、Nitroのnetlify-staticプリセットを使用する場合、Netlify上での出力先は（ローカル環境の.output/publicとは異なり）dist/2019となるため、公開ディレクトリの設定を修正しました。

あわせて、src/ディレクトリ下にある全31個の単一ファイルコンポーネント（SFC）を、推奨されているscript、template、styleタグの順序に整理し、テスト関連のパッケージも最新バージョンに更新しています。